### PR TITLE
creating module: fix setTemplate path

### DIFF
--- a/module/05-CreatingAPrestaShop17Module/05-DisplayingContentOnTheFrontOffice.rst
+++ b/module/05-CreatingAPrestaShop17Module/05-DisplayingContentOnTheFrontOffice.rst
@@ -276,7 +276,7 @@ Here are our two files:
       public function initContent()
       {
         parent::initContent();
-        $this->setTemplate('display.tpl');
+        $this->setTemplate('module:mymodule/views/templates/front/display.tpl');
       }
     }
 


### PR DESCRIPTION
Templating behaviour has changed since 1.7
Current docs are **very** confusing