### PR TITLE
Add Google Analytics to DevDocs

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -5,6 +5,7 @@ title = "Prestashop Developer Documentation"
 
 theme = "hugo-theme-learn"
 enableGitInfo = true
+googleAnalytics = "UA-2753771-44"
 
 [params]
   editURL = "https://github.com/PrestaShop/docs/edit/hugo/src/content/"

--- a/src/themes/hugo-theme-learn/layouts/partials/custom-footer.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/custom-footer.html
@@ -1,5 +1,6 @@
-<!-- Partial intended to be overwritten with tags loaded at the end of the page loading (usually for Javascript) 
+<!-- Partial intended to be overwritten with tags loaded at the end of the page loading (usually for Javascript)
 <script>
     console.log("running some javascript");
 </script>
 -->
+{{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
This PR adds Google Analytics to our documentation, allowing us to know what pages requires the most attention.

- [x] Tracking ID must be owned by PrestaShop organization