### PR TITLE
Fix event name "reponsive update"

### DIFF
--- a/src/content/1.7/themes/reference/javascript-events/_index.md
+++ b/src/content/1.7/themes/reference/javascript-events/_index.md
@@ -58,7 +58,7 @@ Event Name            | Description
  `updateProduct`      | On the product page, selecting a new combination will reload the DOM via ajax calls. After the update, this event is fired.
  `handleError`        | This event is fired after a fail of POST request. Have the `eventType` as first parameter.
  `updateFaces`        | On every product list page (category, search results, pricedrop and so on), the list is updated via ajax calls if you change filters or sorting options. Each time the facets is reloaded, this event is triggered.
- `responsiveUpdate`   | While broswer is resized, this event is fired with a `mobile` parameter.
+ `responsive update`   | While broswer is resized, this event is fired with a `mobile` parameter.
 
 ### Triggering delegated events
 

--- a/src/content/1.7/themes/reference/javascript-events/_index.md
+++ b/src/content/1.7/themes/reference/javascript-events/_index.md
@@ -58,7 +58,7 @@ Event Name            | Description
  `updateProduct`      | On the product page, selecting a new combination will reload the DOM via ajax calls. After the update, this event is fired.
  `handleError`        | This event is fired after a fail of POST request. Have the `eventType` as first parameter.
  `updateFaces`        | On every product list page (category, search results, pricedrop and so on), the list is updated via ajax calls if you change filters or sorting options. Each time the facets is reloaded, this event is triggered.
- `responsive update`   | While broswer is resized, this event is fired with a `mobile` parameter.
+ `responsive update`  | While broswer is resized, this event is fired with a `mobile` parameter.
 
 ### Triggering delegated events
 


### PR DESCRIPTION
Looking at this list: https://devdocs.prestashop.com/1.7/themes/reference/javascript-events/#dispatched-events

The following event is wrong:
`responsiveUpdate`

Reading the documentation one would assume to use it as such:
`prestashop.on("responsiveUpdate", ... );`

White the actual, currect event name and usage is:
`prestashop.on("responsive update", ... );`