### PR TITLE
Update use-hooks-on-modern-pages.md

### DIFF
--- a/src/content/1.7/modules/concepts/hooks/use-hooks-on-modern-pages.md
+++ b/src/content/1.7/modules/concepts/hooks/use-hooks-on-modern-pages.md
@@ -147,6 +147,14 @@ You can now use it in your module (and everywhere in PrestaShop modern pages!):
 ```php
 // foo.php
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+// Add this 
+require_once _PS_MODULE_DIR_.'foo/src/Repository/ProductRepository.php';
+
+
 /* ... */
 /**
  * Get the list of products for a specific lang.


### PR DESCRIPTION
After many search, i had to use this " require_once _PS_MODULE_DIR_.'foo/src/Repository/ProductRepository.php';
 " in my foo.php, to avoid Uncaught PHP Exception Symfony\Component\Debug\Exception\ClassNotFoundException.

And i saw many people asking for it without answer.
So may be this isn't the best solution, but something is missing on this page to make this module work properly.