### PR TITLE
Changing after PHP 5.4

### DIFF
--- a/src/content/1.7/basics/installation/system-requirements.md
+++ b/src/content/1.7/basics/installation/system-requirements.md
@@ -41,9 +41,5 @@ Here is a section of the `php.ini` file (the configuration file for PHP):
 extension = php_mysql.dll
 extension = php_gd2.dll
 allow_url_fopen = On
-
-# also recommended
-register_globals = Off
-magic_quotes_gpc = Off
 allow_url_include = Off
 ```


### PR DESCRIPTION
Configuration not needed because hase removed since php 5.4

register_globals = Off
magic_quotes_gpc = Off