### PR TITLE
Fix Wrong method name

### DIFF
--- a/src/content/1.7/modules/concepts/forms/admin-forms.md
+++ b/src/content/1.7/modules/concepts/forms/admin-forms.md
@@ -19,7 +19,7 @@ Let's see an example on how to add, populate, validate and persist a new form fi
 ```php
 # /modules/module_name/module_name.php
 
-public function hookDisplayAdministrationPageForm(&$hookParams)
+public function hookActionAdministrationPageForm(&$hookParams)
 {
     $formBuilder = $hookParams['form_builder'];
     $uploadQuotaForm = $formBuilder->get('upload_quota');


### PR DESCRIPTION
The method hookDisplayAdministrationPageForm should be named hookActionAdministrationPageForm like the real hook name 
Cf. "action{$this->hookName}Form" in src/Core/Form/FormHandler.php 
It doesn't works with hookDisplayAdministrationPageForm