### PR TITLE
Add deprecation notices

### DIFF
--- a/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
+++ b/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
@@ -1358,6 +1358,8 @@ This hook launches modules when the AdminCategories tab is displayed in the Back
     
 displayBackOfficeFooter
 : 
+    **(deprecated since 1.7.0.0)**
+
     Displayed within the admin panel's footer
 
     Located in: 
@@ -1465,6 +1467,8 @@ This hook calls only the module related to the carrier, in order to add options 
     
 displayCarrierList
 : 
+    **(deprecated since 1.7.0.0)**
+    
     Display extra carriers in the carrier list.
 
     Located in: /classes/Cart.php


### PR DESCRIPTION
Some hooks have been deprecated since 1.7.0. This PR adds deprecation notices to the ones that are documented.

See https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Hook.php#L87-L104