### PR TITLE
Add deprecation notice about PS 1.7.6

### DIFF
--- a/src/content/1.7/modules/core_updates/1.7.6.md
+++ b/src/content/1.7/modules/core_updates/1.7.6.md
@@ -1,0 +1,53 @@
+---
+title: Changes in PrestaShop 1.7.6
+menuTitle: Changes in 1.7.6
+---
+
+# Notable changes in PrestaShop 1.7.6
+
+## CLDR
+
+The CLDR is a component responsible of displaying data such as the date & time, prices depending on a given language. It was reworked during several versions of PrestaShop 1.7, and will be enabled with 1.7.6. The previous one has been removed, and trying to use it will end to an exception.
+
+A new variable is now available in the `Context` when going through a controller:
+
+```php
+class ContextCore
+{
+    /**
+     * Current locale instance.
+     *
+     * @var PrestaShop\PrestaShop\Core\Localization\Locale
+     */
+    public $currentLocale;
+
+    [...]
+}
+```
+
+This property is the link to format properly a number:
+
+```php
+Context::getContext()->currentLocale->formatNumber($number);
+```
+
+or a price:
+
+```php
+Context::getContext()->currentLocale->formatPrice($number);
+```
+
+Note that `Tools::displayNumber(...)` and`Tools::displayPrice(...)` works as before, although deprecated.
+
+For more details, please see [the related pull-request on GitHub](https://github.com/PrestaShop/PrestaShop/pull/12999). The summary of removed elements is the following:
+
+Removed classes:
+
+* `PrestaShop\PrestaShop\Core\Cldr\Composer\Hook`
+* `PrestaShop\PrestaShop\Core\Cldr\Localize`
+* `PrestaShop\PrestaShop\Core\Cldr\Repository`
+* `PrestaShop\PrestaShop\Core\Cldr\Update`
+
+Deprecated methods:
+
+* `Tools::getCldr(...)`


### PR DESCRIPTION
 This new page deals with the new CLDR introduced on PS 1.7.6 and warns about the removed stuff from the old one.