### PR TITLE
Improve PHP compatibility chart

### DIFF
--- a/src/content/1.7/basics/installation/system-requirements.md
+++ b/src/content/1.7/basics/installation/system-requirements.md
@@ -4,21 +4,28 @@ menuTitle: System requirements
 weight: 10
 ---
 
+<style type="text/css">
+.support-yes, .example-yes {
+  background-color: #8ce48c;
+}
+.support-no, .example-no {
+  background-color: #e89b9b;
+}
+.example-yes, .example-no {
+  display: inline-block;
+  width: 1.1rem; 
+  height: 1.1rem;
+  margin-bottom: -2px;
+}
+</style>
+
 # System requirements for PrestaShop 1.7
 
 PrestaShop needs the following server configuration in order to run:
 
 * **System:** Unix, Linux or Windows.
 * **Web server:** Apache Web Server 2.2 or any later version.
-* **PHP:** 
-
-    | PrestaShop Version | Minimum | Recommended | Not compatible
-    | --- | --- | --- | ---
-    | 1.6.1.x | PHP 5.2 | PHP 7.1 | PHP 7.2+
-    | 1.7.0 ~ 1.7.3 | PHP 5.4 | PHP 7.1 | PHP 7.2+
-    | 1.7.4 | PHP 5.6 | PHP 7.1 | PHP 7.2+
-    | 1.7.5 | PHP 5.6 | PHP 7.2 | PHP 7.3+
-
+* **PHP:** We recommend PHP 7.1 or later. See the compatibility chart below for more details. 
 * **MySQL:** 5.0 minimum, 5.6 or later recommended.
 * **Server RAM:** The more the better. We recommend setting the memory allocation per script (`memory_limit`) to a minimum of `256M`.
 
@@ -26,7 +33,105 @@ PrestaShop can also work with Microsoft’s IIS Web server 6.0 or later, and ngi
 
 ## PHP requirements
 
-PrestaShop needs a few additions to PHP and MySQL in order to fully work. Make sure that your PHP configuration has the following settings and tools:
+### PHP compatibility chart
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th colspan="10" style="text-align:center">PHP Version</th>
+    </tr>
+    <tr>
+      <th>PrestaShop Version</th>
+      <th>&lt;=&nbsp;5.1</th>
+      <th>5.2</th>
+      <th>5.3</th>
+      <th>5.4</th>
+      <th>5.5</th>
+      <th>5.6</th>
+      <th>7.0</th>
+      <th>7.1</th>
+      <th>7.2</th>
+      <th>&gt;=&nbsp;7.3</th>
+    </tr>
+  </thead>
+<tbody>
+  <tr>
+    <td>1.6.1.x</td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes">
+      <i class="fa fa-check" aria-hidden="true" title="title="Recommended version"></i>
+      <span class="sr-only">Recommended version</span>
+    </td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+  </tr>
+  <tr>
+    <td>1.7.0 ~ 1.7.3</td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes">
+      <i class="fa fa-check" aria-hidden="true" title="title="Recommended version"></i>
+      <span class="sr-only">Recommended version</span>
+    </td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+  </tr>
+  <tr>
+    <td>1.7.4</td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes">
+      <i class="fa fa-check" aria-hidden="true" title="title="Recommended version"></i>
+      <span class="sr-only">Recommended version</span>
+    </td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+  </tr>
+  <tr>
+    <td>1.7.5 ~ 1.7.6</td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes">
+      <i class="fa fa-check" aria-hidden="true" title="title="Recommended version"></i>
+      <span class="sr-only">Recommended version</span>
+    </td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+  </tr>
+</tbody>
+</table>
+
+**Legend:**
+
+<i class="fa fa-check" aria-hidden="true"></i> = Recommended version
+<span class="example-yes"></span><span class="sr-only">Yes</span> = Supported
+<span class="example-no"></span><span class="sr-only">No</span> = Not supported
+
+
+
+PrestaShop needs a few additions to PHP and MySQL in order to fully work. Make sure that your PHP configuration has the following extensions and settings configured:
 
 ### Extensions
 


### PR DESCRIPTION
Improve PHP compatibility chart. It requires HTML but it looks better :)

<img width="829" alt="Screenshot 2019-04-24 at 13 48 19" src="https://user-images.githubusercontent.com/1009343/56657250-d9b31d80-6697-11e9-9781-5292143721da.png">
