### PR TITLE
All calls to this hook don't pass the $_POST object.

### DIFF
--- a/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
+++ b/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
@@ -405,7 +405,6 @@ actionCustomerAccountAdd
     Parameters:
     ```php
     array(
-      '_POST' => (array) $_POST,
       'newCustomer' => (object) Customer object
     );
     ```


### PR DESCRIPTION
Although this would be very useful it is not like this in this moment.