### PR TITLE
Update on the PrestaShop DevDocs about the hook on the moderns pages

### DIFF
--- a/src/content/1.7/modules/concepts/hooks/use-hooks-on-modern-pages.md
+++ b/src/content/1.7/modules/concepts/hooks/use-hooks-on-modern-pages.md
@@ -72,12 +72,12 @@ class ProductRepository
     /**
      * @var string the Database prefix.
      */
-    private $databasePrefix;
+    private $dbPrefix;
 
-    public function __construct(Connection $connection, $databasePrefix)
+    public function __construct(Connection $connection, $dbPrefix)
     {
         $this->connection = $connection;
-        $this->databasePrefix = $databasePrefix;
+        $this->dbPrefix = $dbPrefix;
     }
 
     /**
@@ -86,7 +86,7 @@ class ProductRepository
      */
     public function findAllbyLangId(int $langId)
     {
-        $prefix = $this->databasePrefix;
+        $prefix = $this->dbPrefix;
         $productTable = "${prefix}product";
         $productLangTable = "${prefix}product_lang";
 


### PR DESCRIPTION
Hello I want to contribute to the community so here is my proposition. I was learning the prestashop 1.7.6 with this doc but it's not up to date so the part on the hooks on moderne pages wasn't working. I had to change the namespace and to create the method getRepository to create the repository and load the service without this, the erreur : You have requested a non-existent service is thrown