### PR TITLE
Better structure for module extension symfony concepts

### DIFF
--- a/src/content/1.7/modules/concepts/_index.md
+++ b/src/content/1.7/modules/concepts/_index.md
@@ -6,21 +6,4 @@ chapter: true
 
 # Extension concepts
 
-## Symfony extension concepts
-
-PrestaShop modules acts as Symfony bundles, extension points are added continuously in each minor version:
-
-| Version  | Symfony features                                               |
-|----------|----------------------------------------------------------------|
-| 1.7.3    | [Twig templates][1] and [Services][2]                          |
-| 1.7.4    | [Configuration Forms][3] and [Console commands][4]             |
-| 1.7.5    | [Modern controllers and Security][5]                           |
-| 1.7.6    | [Doctrine ORM][6] and [Entity forms][7]                        |
-
-[1]: {{< ref "1.7/modules/concepts/templating/_index.md" >}}
-[2]: {{< ref "1.7/modules/concepts/services/_index.md" >}}
-[3]: {{< ref "1.7/modules/concepts/forms/admin-forms.md" >}}
-[4]: {{< ref "1.7/modules/concepts/commands.md" >}}
-[5]: {{< ref "1.7/modules/concepts/controllers/admin-controllers/_index.md" >}}
-[6]: {{< ref "1.7/modules/concepts/doctrine/_index.md" >}}
-[7]: {{< ref "1.7/modules/sample_modules/grid-and-identifiable-object-form-hooks-usage/_index.md" >}}
+{{% children %}}

--- a/src/content/1.7/modules/concepts/symfony.md
+++ b/src/content/1.7/modules/concepts/symfony.md
@@ -1,0 +1,23 @@
+---
+title: Symfony extension concepts
+weight: 8
+---
+
+# Symfony extension concepts
+
+PrestaShop modules acts as Symfony bundles, extension points are added continuously in each minor version:
+
+| Version  | Symfony features                                               |
+|----------|----------------------------------------------------------------|
+| 1.7.3    | [Twig templates][1] and [Services][2]                          |
+| 1.7.4    | [Configuration Forms][3] and [Console commands][4]             |
+| 1.7.5    | [Modern controllers and Security][5]                           |
+| 1.7.6    | [Doctrine ORM][6] and [Entity forms][7]                        |
+
+[1]: {{< ref "1.7/modules/concepts/templating/_index.md" >}}
+[2]: {{< ref "1.7/modules/concepts/services/_index.md" >}}
+[3]: {{< ref "1.7/modules/concepts/forms/admin-forms.md" >}}
+[4]: {{< ref "1.7/modules/concepts/commands.md" >}}
+[5]: {{< ref "1.7/modules/concepts/controllers/admin-controllers/_index.md" >}}
+[6]: {{< ref "1.7/modules/concepts/doctrine/_index.md" >}}
+[7]: {{< ref "1.7/modules/sample_modules/grid-and-identifiable-object-form-hooks-usage/_index.md" >}}


### PR DESCRIPTION
Right now, clicking on "https://devdocs.prestashop.com/1.7/modules/concepts/" you are directly prompted Symfony extension concepts instead of a summary of all possible extension concepts. This PR fixes that.