### PR TITLE
Update admin controllers documentation

### DIFF
--- a/src/content/1.7/modules/concepts/controllers/admin-controllers/_index.md
+++ b/src/content/1.7/modules/concepts/controllers/admin-controllers/_index.md
@@ -64,6 +64,9 @@ You must enable the autoloading for this Controller. For example using a `compos
           "MyModule\\Controller\\": "controller/"
         }
       },
+      "config": {
+          "prepend-autoloader": false
+      },
       "type": "prestashop-module"
     }
     ```


### PR DESCRIPTION
Add `prepend-autoloader` to the example composer.json as mentioned at https://devdocs.prestashop.com/1.7/modules/concepts/composer/#important-notes