### PR TITLE
Import severity and review process build articles into the doc

### DIFF
--- a/src/content/1.7/contribute/contribute_using_docker.md
+++ b/src/content/1.7/contribute/contribute_using_docker.md
@@ -1,6 +1,6 @@
 ---
 title: Contribute using Docker
-weight: 2
+weight: 3
 ---
 
 # How to become a Core Contributor using Docker

--- a/src/content/1.7/contribute/how-issues-are-sorted.md
+++ b/src/content/1.7/contribute/how-issues-are-sorted.md
@@ -1,0 +1,101 @@
+---
+title: How issues are sorted
+weight: 4
+---
+
+# How issues are sorted
+
+## What happens to the issue you have reported ?
+
+PrestaShop Quality Assurance team (aka QA) uses a transparent definition for the criteria used to qualify issues' severity, and how they should be applied through labels on github issues.
+
+Please note that severity is to be distinguished from priority. Indeed, severity is used to measure the negative impact that a bug has on a system, a feature, a component or on the project development. It is usually defined by the QA team. As for the priority, it is used to organize all the tasks (bugs, improvements, features, technical tasks) that have to be done in order to meet the project's deadlines. 
+
+
+## Issue Severity Criteria
+
+When a new issue is created, the first step is to understand what the problem is and then reproduce it. Once that work is done, the second step is to define the severity of that bug.
+
+Four severity levels are used:
+
+### Critical
+
+The bug affects critical functionality or critical data and there is no workaround (no way to avoid it).
+A critical issue affects a very large percentage of users (> 60%) and matches at least one of the following:
+
+- It can lead to data loss, introduce a security vulnerability or break the automatic end to end tests
+- It prevents the essential shop operations or puts your business at great risk
+
+Examples:
+
+- Difficulty accessing the front office or back office (significant slowdown, error during installation or update, fatal error)
+- Difficulty to globally manage categories, products or customers
+- Difficulty to globally place and manage orders
+
+A critical issue should result in a patch version that should be released as soon as possible. [PrestaShop 1.7.2.5](http://build.prestashop.com/news/prestashop-1-7-2-5-maintenance-release/) is a good example: this patch release fixes two vulnerabilities affecting the Back Office.
+
+
+### Major
+
+The bug affects major functionality or major data and there is a workaround, but it is not obvious or can be difficult to put in practice.
+
+A major issue affects a large percentage of users (> 30%) and matches at least one of the following:
+
+- It impacts law compliance
+- It has a strong impact on the usability of the front-office / back-office or blocks another project
+- It is an important problem but not necessarily blocking the main activity of the seller
+
+Examples:
+
+- Being unable to add, configure or delete a theme or a module
+- Difficulty in operating a module properly
+- Impacts the price the customer pays
+
+### Minor
+
+The bug affects minor functionality or non-critical data and there is a reasonable workaround, even if it can be annoying when using your shop.
+
+
+Examples:
+
+- A tolerable slowdown
+- A display problem that prevents users from doing something non-critical (eg: can’t click on an element that can be accessible in another way)
+- An error message displayed in your back-office that can be dismissed
+- Cloning a product doesn't copy all of it's data
+- Inaccurate statistics
+
+
+### Trivial
+
+The bug doesn’t affect any functionality or data. It does not impact productivity or efficiency. It is only an inconvenience without functional impact and it does not even need a workaround.
+
+Examples:
+
+- Cosmetic issues
+- Wrong translation in a specific language: that can be solved on [Crowdin](https://crowdin.com/project/prestashop-official)
+- Missing confirmation message after an action
+- A link opened in the same tab instead of a new tab
+
+
+## Issue Prioritization
+
+Assessing severity helps to prioritize issues but it is not the only criterion at stake. Given two equally severe issues, how to choose one over the other ?
+
+Prioritization is done by representatives of the Development team, the Product Management team, and the Quality Assurance team.
+
+Together, during regular meetings, they look at the new confirmed issues and they sort them.
+
+In order to make sure that a given bug does not damage PrestaShop's image nor it affects the confidence merchants can have in PrestaShop, they take special care and strive to make every version of PrestaShop better than the one before. Since no one wants to introduce new bugs while fixing other bugs, regressions (new bugs created accidentally when fixing or improving an existing feature) are usually prioritized higher than older bugs. By doing this, the overall software stability is ever increasing.
+
+Then the issue's technical complexity is also studied : that is, whether the bug is easy or complex to fix.
+
+Sometimes a smaller bug will be prioritize over a bigger one. This is because a complex bug may require big technical changes which are not suitable until a later version. This may be because a would require applying backwards-incompatible changes (which are bad for module developers), or because it can be better addressed as a part of a larger project – there is no use fixing a bug if the whole feature is due to be revamped in the near future.
+Also sometimes some bugs will be prioritized just because of the “opportunity cost” of fixing them together, as it is usually easier to fix several bugs within the same component. For instance, during the migration of a BO page to Symfony, the bugs of this page are prioritized higher in order to fix them all at once.
+
+Last criterion used is the business impact as of course.
+
+In the end, handling bugs requires two points of view: micro and macro. Severity analyzes the issue on its own, while Priority analyzes the issue in the context of the whole project.
+
+<hr />
+
+This page is a (reworked) copy of http://build.prestashop.com/news/severity-classification/ .

--- a/src/content/1.7/contribute/how-pull-requests-are-processed.md
+++ b/src/content/1.7/contribute/how-pull-requests-are-processed.md
@@ -1,0 +1,80 @@
+---
+title: How Pull Requests are processed
+weight: 6
+---
+
+# How issues are sorted
+
+## What happens to the pull request you have submitted ?
+
+All submitted pull requests go through a thorough process which aims to provide a stable, consistent and reliable software that we all know under the name PrestaShop. Here is this process in details.
+
+## Automatic tasks when you open a Pull Request
+
+When you submit a new Pull Request to the project repository https://github.com/PrestaShop/PrestaShop, some automatic checks are triggered.
+
+### Continuous Integration
+
+Two automatic code checker tools are active on the project.
+
+The first tool is [PrettyCI](https://prettyci.com/). This tool will look at your Pull Request and check whether the code-style is correct. If not, it will block the PR from being merged and tell you what is wrong.
+
+It is a lot easier to work on a big codebase like PrestaShop if all code is written following the same conventions: snake_case or camelCase, how to write the phpDoc, when to use white spaces ... it makes the code look like if it was written by a single developer.
+Just like reading a book with two different styles in it, having a codebase with a unified style is making it easier to browse. A unified code-style also makes the pull requests easier to review.
+
+If PrettyCI states that your pull request has issues, you need to fix the issues by looking at PrettyCI output to understand what needs to be fixed.
+
+The second tool is [Travis](http://travis-ci.org/). Travis is a Continous Integration system that will look at the Pull Request and run several checks, be it code-style checkers, format checkers or automated tests, and provide you the result in the Pull Request. If something is wrong it will block the PR from being merged. This is a standard approach to ensure that new contributions in a codebase do not break existing features and behaviors.
+
+If Travis states that your pull request has issues, you need to fix the issues by looking at Travis output to understand what needs to be fixed.
+
+These tools are executed automatically for every Pull Request.
+
+In addition, the new [Github Actions](https://github.com/features/actions) have been activated on the `develop` branch, which now benefits from an additional php 7.2 syntax compliancy check.
+
+### Prestonbot
+
+[Prestonbot](https://github.com/PrestaShop/prestonbot) is a custom bot that looks at all Pull Requests and tries to help us manage the project. He has multiple capabilities.
+
+For example he detects mistakes in the pull request description, he add some labels to classify the pull requests, he welcomes new contributors to the project ...
+
+[Read his article for the full details.](http://build.prestashop.com/news/prestonbot-reaches-stable-version/)
+
+If something is wrong, Prestonbot will write a comment in the pull request to tell you what to fix.
+
+## The code review
+
+Your Pull Request will be reviewed by a Core maintainer.
+
+### What is being checked in code review?
+
+When a Core maintainer sees a pull request, they will review it and decide whether it should be accepted, if it needs changes, or if it cannot be accepted.
+
+The review process is quite thorough in order to make sure that PrestaShop codebase gets better with each contribution. Here is all the things looked for in a Pull Request, when reviewing it:
+
+- The start is checking that the code is correct. This means both from a behavior point of view as well as from a technical point of view. This is simply an assessment of the quality of the Pull Request code, just like it happens in a lot of software teams. The Core maintainers check the code works as intended, it uses the right functions, it handles expectable edge-cases, has no obvious vulnerabilities, scales well, etc. The Core maintainers also keep in mind that PrestaShop is a CMS and consequently must provide all the necessary extension points to allow developers to customize or extend its behavior.
+- The Core maintainers also assess the readability of the code. There is a statement that says "when a code file is opened by a developer, 9 times out of 10 it will only to be read, not to be modified". Because PrestaShop is a huge and complex codebase and because it has so many people reading through it, it is very important that its code is made as readable as possible. This is obtained by adding comments, carefully choosing function and variable names, and building an architecture that makes sense so it is easy to grasp and navigate for people who have never worked on it before.
+- The Core maintainers also check that best practices are implemented into the Pull Request, be it standard conventions or practices like [PSR](https://www.php-fig.org/psr/) or best security recommandations like the ones from [OWASP](https://www.owasp.org/). When people use PrestaShop to build a shop, it is likely that they will follow the practices they see implemented in the Core, so the aim is to think of the code merged as an example that people will use.
+- PrestaShop has grown huge over the years, both as a codebase and as a software. There are hundreds of features built in the software, and some are more commonly used than others. Some contributions sometimes need to be reworked because they did not take into account one of the less popular features of the software, or are not compatible with them. Common examples are the multi-store mode or the RTL (Right-To-Left) mode, two features that adress very specific needs and that many developers are not aware of.
+- PrestaShop follows [SemVer](https://semver.org/). This means that The Core maintainers strive not to introduce breaking compatibility changes when releasing minor and patch versions. Therefore, each Pull Request must not introduce such changes.
+- The Core maintainers also have a vision of what PrestaShop should evolve to in order to follow the new trends in the software world. Although a big codebase like PrestaShop evolves slowly, the future architecture and features to come are kept in mind, and the Core maintainers check whether the Pull Request is following this direction. For example today PrestaShop relies heavily on jQuery for its frontend features, and Vue.js is slowly starting to be used in the project. So if tomorrow a Pull Request that is using React.js is submitted, it might be refused in order to keep a consistency in the technology stack used for the project.
+
+Some Pull Requests are very hard to review because they are related to a complex topic, a complex area of the code or have a huge global impact on the software that is very hard to estimate and assess. Reviews can take hours or days in order to make sure every contribution merged in the project meets the level of quality we want for it.
+
+Most of the time, if an issue is found during the review, the Core maintainer will provide feedback about the issue and requests the author to modify the parts of the Pull Request that cannot be accepted as they are. After the author of the Pull Request has implemented the requested changes, then the Pull Request can be approved and move forward to the next step.
+
+### It is not only about code
+
+For some Pull Requests, some more people of PrestaShop might be involved in the review:
+
+- UX design team will review changes that have a significant UX impact 
+- Product team will review changes that introduce a significant behavior modification (either an existing feature or a new feature)
+- Content team will review Pull Requests that introduce wording changes (labels, titles, error and information messages)
+
+Once the Pull Request has been validated by all of the relevant people, it is finally verified by the QA team. The QA team will then make sure that the behavior of the proposed change is correct and that it does not produce any regressions (new errors).
+
+After the Pull Request has finally passed the QA validation, it is merged in the project and the author becomes (if they weren't already) a contributor to this great open source project !
+
+<hr />
+
+This page is a (reworked) copy of http://build.prestashop.com/news/the-review-process/ .


### PR DESCRIPTION
I have imported the content of http://build.prestashop.com/news/the-review-process/ and http://build.prestashop.com/news/severity-classification/ into the docs. I rewrote them a bit as the audience is not the same (I removed mainly the "we" and the buddy-style statements to make it more formal and more impersonal).