### PR TITLE
Improve hook example for form hooks usage

### DIFF
--- a/src/content/1.7/modules/sample_modules/grid-and-identifiable-object-form-hooks-usage.md
+++ b/src/content/1.7/modules/sample_modules/grid-and-identifiable-object-form-hooks-usage.md
@@ -239,6 +239,7 @@ You can find full implementation [here](https://github.com/PrestaShop/demo-cqrs-
 // modules/ps_democqrshooksusage/ps_democqrshooksusage.php
 
 use Symfony\Component\Form\FormBuilderInterface;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
 
 public function hookActionCustomerFormBuilderModifier(array $params)
 {


### PR DESCRIPTION
In Adding new form field to customer form we need SwitchType, so I add this line "use PrestaShopBundle\Form\Admin\Type\SwitchType;"