### PR TITLE
Update Hugo to 0.59.0

### DIFF
--- a/bin/installHugo.sh
+++ b/bin/installHugo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-export HUGO_VERSION="0.46"
+export HUGO_VERSION="0.59.0"
 wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
 tar -xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz hugo && rm hugo_${HUGO_VERSION}_Linux-64bit.tar.gz


### PR DESCRIPTION
Note that when running Hugo there is a warning related to this file: https://github.com/PrestaShop/docs/blob/master/src/themes/hugo-theme-learn/layouts/partials/menu.html#L144

It's a deprecation notice so nothing too serious for now.

Related theme issue here: https://github.com/matcornic/hugo-theme-learn/issues/329