### PR TITLE
Fix shortcodes following changes in Hugo 0.55

### DIFF
--- a/src/themes/hugo-theme-learn/layouts/shortcodes/callout.html
+++ b/src/themes/hugo-theme-learn/layouts/shortcodes/callout.html
@@ -1,1 +1,1 @@
-<div class="callout">{{ .Inner }}</div>
+<div class="callout">{{ .Inner | markdownify }}</div>

--- a/src/themes/hugo-theme-learn/layouts/shortcodes/funcdef.html
+++ b/src/themes/hugo-theme-learn/layouts/shortcodes/funcdef.html
@@ -1,3 +1,3 @@
 <div class="function-definition">
-{{ .Inner }}
+{{ .Inner | markdownify }}
 </div>

--- a/src/themes/hugo-theme-learn/layouts/shortcodes/md.html
+++ b/src/themes/hugo-theme-learn/layouts/shortcodes/md.html
@@ -1,1 +1,1 @@
-{{ .Inner }}
+{{ .Inner | markdownify }}

--- a/src/themes/hugo-theme-learn/layouts/shortcodes/notice.html
+++ b/src/themes/hugo-theme-learn/layouts/shortcodes/notice.html
@@ -1,1 +1,1 @@
-<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>{{ .Inner }}</div>
+<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>{{ .Inner | markdownify }}</div>


### PR DESCRIPTION
Following [a change in Hugo 0.55](https://gohugo.io/news/0.55.0-relnotes/#shortcodes-revised), content in shortcodes (notice, funcdef, callout...) weren't being parsed to markdown anymore.

The solution, [as found here](https://discourse.gohugo.io/t/misunderstanding-of-shortcode-syntax-in-0-55/18538), is to pass the contents through the markdownify function.

I verified that it's working correctly.