### PR TITLE
Fix example controller name to be more coherent and usage of translator

### DIFF
--- a/src/content/1.7/modules/creation/module-translation/new-system.md
+++ b/src/content/1.7/modules/creation/module-translation/new-system.md
@@ -140,7 +140,7 @@ Since the module is called MyModule, the translation domain should be `Modules.M
 ```php
 // file: controllers/front/something.php
 
-class MyModuleSomethingFrontController extends ModuleFrontController
+class MySomethingModuleFrontController extends ModuleFrontController
 {
     public function initContent()
     {

--- a/src/content/1.7/modules/creation/module-translation/new-system.md
+++ b/src/content/1.7/modules/creation/module-translation/new-system.md
@@ -140,7 +140,7 @@ Since the module is called MyModule, the translation domain should be `Modules.M
 ```php
 // file: controllers/front/something.php
 
-class MySomethingModuleFrontController extends ModuleFrontController
+class MymoduleSomethingModuleFrontController extends ModuleFrontController
 {
     public function initContent()
     {

--- a/src/content/1.7/modules/creation/module-translation/new-system.md
+++ b/src/content/1.7/modules/creation/module-translation/new-system.md
@@ -144,7 +144,7 @@ class MySomethingModuleFrontController extends ModuleFrontController
 {
     public function initContent()
     {
-        $this->title = $this->module->trans('My module title', [], 'Modules.Mymodule.Something);
+        $this->title = $this->trans('My module title', [], 'Modules.Mymodule.Something);
     }
 }
 ```


### PR DESCRIPTION
Fixed example controller name to fit with naming convention (see https://devdocs.prestashop.com/1.7/modules/concepts/controllers/front-controllers/)

Thanks to @BlackKerio for the hint