### PR TITLE
Add mbstring as required

### DIFF
--- a/src/content/1.7/basics/installation/system-requirements.md
+++ b/src/content/1.7/basics/installation/system-requirements.md
@@ -181,6 +181,7 @@ PrestaShop needs a few additions to PHP and MySQL in order to fully work. Make s
 * **Fileinfo**. The [File information extension](https://php.net/manual/en/book.fileinfo.php) is used to find out the file type of uploaded files.
 * **GD**. The [GD extension](https://php.net/manual/en/book.image.php) is used to create thumbnails for the images that you upload.
 * **Intl**. The [Internationalization extension](https://php.net/manual/en/book.intl.php) is used to display localized data, such as amounts in different currencies.
+* **Mbstring**. The [Multibyte string extension](https://www.php.net/manual/en/book.mbstring.php) to perform string operations everywhere.
 * **Zip**. The [Zip extension](https://php.net/manual/en/book.zip.php) is used to expand compressed files such as modules and localization packages.
 
 ### Settings


### PR DESCRIPTION
Mbstring has always been required AFAIK. It's already marked as non-optional in php-ps-info: https://github.com/PrestaShop/php-ps-info/blob/master/phppsinfo.php#L29

Related issue: https://github.com/PrestaShop/PrestaShop/issues/9583