### PR TITLE
Fix formatting .`tpl` -> `.tpl`

### DIFF
--- a/src/content/1.7/modules/creation/displaying-content-in-front-office.md
+++ b/src/content/1.7/modules/creation/displaying-content-in-front-office.md
@@ -110,7 +110,7 @@ Displaying content
 Now that we have access to the left column, we should display something
 there for the customer to see.
 
-The visible part of the module is defined in .`tpl` files placed in
+The visible part of the module is defined in `.tpl` files placed in
 specific View folders:
 
 -   `/views/templates/front/`: front office features.


### PR DESCRIPTION
Saw that formatting issue while I was reading the docs. I'm quite sure .`tpl` should be `.tpl`