### PR TITLE
Note deprecated hook

### DIFF
--- a/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
+++ b/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
@@ -308,6 +308,8 @@ actionBeforeAjaxDie&lt;ControllerName>&lt;Method>
     
 actionBeforeCartUpdateQty
 : 
+    **(deprecated since 1.6.1.1)**
+    
     Located in: /classes/Cart.php
 
     

--- a/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
+++ b/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
@@ -309,6 +309,7 @@ actionBeforeAjaxDie&lt;ControllerName>&lt;Method>
 actionBeforeCartUpdateQty
 : 
     **(deprecated since 1.6.1.1)**
+    → `actionCartUpdateQuantityBefore`
     
     Located in: /classes/Cart.php
 


### PR DESCRIPTION
`actionBeforeCartUpdateQty` is deprecated and commented out in `classes/Cart.php` as it's replaced by `actionCartUpdateQuantityBefore`.