### PR TITLE
Minor typo on Embedding a template in the theme section

### DIFF
--- a/src/content/1.7/modules/creation/displaying-content-in-front-office.md
+++ b/src/content/1.7/modules/creation/displaying-content-in-front-office.md
@@ -356,7 +356,7 @@ public function hookDisplayLeftColumn($params)
             'my_module_link' => $this->context->link->getModuleLink('mymodule', 'display'),
             'my_module_message' => $this->l('This is a simple text message') // Do not forget to enclose your strings in the l() translation method
         ]
-    ];
+    );
 
     return $this->display(__FILE__, 'mymodule.tpl');
 }


### PR DESCRIPTION
On the example "public function hookDisplayLeftColumn($params)" there was a square bracket closing the smarty-assing instruction and should be a parenthesis