### PR TITLE
Copy release lifecycle posts into devdoc

### DIFF
--- a/src/content/1.7/release/_index.md
+++ b/src/content/1.7/release/_index.md
@@ -1,0 +1,14 @@
+---
+title: Release
+weight: 9
+pre: "<b>9. </b>"
+chapter: true
+---
+
+### Chapter 9
+
+# Releasing PrestaShop software
+
+This sections aims to explain the different concepts and processes behind releasing a new version of PrestaShop.
+
+{{% children %}}

--- a/src/content/1.7/release/minor-release-lifecycle.md
+++ b/src/content/1.7/release/minor-release-lifecycle.md
@@ -1,0 +1,49 @@
+---
+title: Patch release lifecycle
+weight: 2
+---
+
+# Patch release lifecycle
+
+Patch releases are "maintainance" releases: they provide bug fixes and security patches, but do not provide enhancements or new features. They are part of a necessary maintenance process.
+
+### Scope of maintainance
+
+When a minor version is released, such as PrestaShop 1.7.7.0, the related branch becomes the latest and maintained branch.
+This means that, when PrestaShop 1.7.7.0 is out :
+- There will be no more PrestaShop 1.7.6 patch releases, for either bug or security issues
+- There might be, if necessary, patch releases for PrestaShop 1.7.7. (which means: 1.7.7.1, 1.7.7.2 and so on ...) until next minor release is delivered (PrestaShop 1.7.8)
+
+When PrestaShop 1.7.7.0 is released, PrestaShop 1.7.6 reaches its [End Of Life](https://en.wikipedia.org/wiki/End-of-life_(product)), just like all previous minor versions.
+
+### When is it decided to release a patch ?
+
+A patch release is scheduled when a "trigger bug" is reported:
+- A major bug in maintained branch
+- A security issue in maintained branch
+
+For example, let's see 1.7.7.0 lifecycle:
+
+Until PrestaShop 1.7.7.0 is released, the maintained branch remains `1.7.6.x`.
+
+This means that **work on a new 1.7.6 release will start if a community contributor or the QA team reports a major regression in PrestaShop 1.7.6 or a security issue.**
+
+If minor or trivial regressions are reported for PrestaShop 1.7.6, they are scheduled to be fixed in next minor version. Minor or trivial bugs are considered not important enough to trigger a patch release process which is, as explained below, a costly process for both the PrestaShop company and the PrestaShop community.
+
+From the moment a "trigger bug" is reported, there start a *6 weeks long timer*. Our process states that a patch release must be delivered within these 6 weeks.
+
+### What happens in six weeks
+
+From the moment the 6 weeks timer is started, Product Team register into the dedicated Kanban the bugs to be fixed in the patch release, whether they are trivial, minor or major.
+
+Then maintainers start working on fixing them (or merging the bug fixes submitted by the community).
+
+Obviously, security issues are not processed the same way: when a vulnerability is reported, it is being explored and it is being fixed in a hidden manner in order to make sure hackers unaware of the vulnerability do not hear about it. We use [GitHub Security Advisories](https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories) and temporary private forks to collaborate on the fix. Maintainers only publish the advisory and the fix on the day of the release, following [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) principle.
+
+When all bug fixes for the target patch version are merged, and all teams pressure themselves to make it happen before the end of the 6 weeks, maintainers deliver a Release Candidate to QA team for the **standard patch release test campaign**. This test campaign aims to find whether this patch introduces new bugs.
+
+If the campaign reports that no bugs are found, the new patch release is validated by QA team and can be delivered!
+
+
+_(This article was originally published on our blog: [PrestaShop 1.7 Patch Release Lifecycle
+](https://build.prestashop.com/news/ps17-minor-release-lifecycle/))_

--- a/src/content/1.7/release/patch-release-lifecycle.md
+++ b/src/content/1.7/release/patch-release-lifecycle.md
@@ -1,0 +1,101 @@
+---
+title: Minor release lifecycle
+weight: 1
+---
+
+# Minor release lifecycle
+
+## Kanban and scope
+
+Each minor version is defined by a feature scope, that is, a number of GitHub issues that we put in a version [Kanban](https://help.github.com/en/github/managing-your-work-on-github/about-project-boards). How these issues are picked or sorted is the responsibility of the Product Team, who spends a lot of time gathering feedback from the PrestaShop community to make sure the next minor version addresses the most important needs.
+
+For example PrestaShop 1.7.7.0 scope contained, but not only:
+
+- Compatibility with php 7.3
+- Migration and rework of Back-office Order pages
+- Advanced currencies management
+
+Although it is very hard to estimate the size of this scope, we try to size it in order for the development phase to last 4 months.
+
+Once this scope has been is completed – i.e all issues have reached the "Done" column of the Kanban – the project reaches the [Feature Freeze](https://en.wikipedia.org/wiki/Freeze_(software_engineering)) stage.
+
+During this phase, no new items can be added to the version's scope, unless they are bugs related to code changes performed during the development of this version – called _regressions_). However, this is a _Feature Freeze_, not a _Code Freeze_, so some older bugs may be added to the scope if it is considered opportune to fix them quickly before the release is out (e.g. security fixes).
+
+## Feature Freeze
+
+Feature freeze means that all features of this version have been done and no new ones may be accepted in its scope. The project enters a phase of _stabilization_ whose aim is to identify and fix all regressions) before it's released.
+
+Once this phase is started, Core maintainers create a git branch from `develop` branch which will carry the work to be done until the release (for 1.7.7.0, the branch name was `1.7.7.x`). From this moment on, only bug fixes can be merged into this branch. Incidentally, this is also the branch where all future patch versions for this minor version will be developed on (hence the `.x` at the end).
+
+Also, since stabilization is performed in a separate branch (`1.7.7.x` in our example), development for the next minor release (1.7.8 in our example) can start on the `develop` branch. This means that the development of any given minor version development actually starts (albeit slowly) precisely the moment the previous version enters feature freeze.
+
+The QA team picks up the latest [nightly build](https://nightly.prestashop.com/) and starts a huge test campaign. The goal of this campaign is to find and register all regressions of this build.
+
+As the QA team verifies the build, they will populate the Kanban with all the bugs they find.
+All important regressions must be fixed quickly. Although it depends heavily on the number of regressions found, this phase should last about one month. Once all major bugs have been fixed, the [Beta phase](https://en.wikipedia.org/wiki/Software_release_life_cycle#Beta) can be launched.
+
+## Public Beta period
+
+When the branch reaches a point of maturity, which means only minor or trivial issues remain to be fixed, maintainers can create a Beta build using the `.x` branch codebase.
+
+This Beta build is released publicly. During the month following this release, the community is **very strongly encouraged to test it** and give their feedback quickly: the sooner a problem is identified, the sooner it will be fixed. Remember that experts agree that the cost of fixing a bug grows exponentially with time – it is much cheaper to spend time now to ensure everything works well before the final release is out than to discover a bug in production later and lose business while a patch is prepared.
+
+During this one month, we continue testing and fixing the `.x` (following the stabilization goal) but we know that we can only test and imagine a limited amount of usecases. The community however knows better than us all the possible ways to use PrestaShop to build a business.
+
+So **everybody can help** make this release better and more stable by testing it during the Beta phase.
+
+What does it mean to test a Beta build?
+
+- If you use PrestaShop web services API for integration with other systems, make sure they work as expected
+- If you build 1.7 modules or themes, test them on the new version
+- If you know very well some of the modified/improved/reworked Back-office pages, please give them a try
+- If you customized some parts of the shop, make sure they work well in the new version
+- If you are hosting shops or providing maintenance services to merchants, import the data of one or two typical shops on a pre-production server and check the performance and the behavior of this version; you can also check that the update process is working as expected, depending on your favorite method
+
+For example, if you are a payment module developer, just installing your module on this Beta software, processing one payment and telling us that everything is running as expected is already a great feedback.
+
+If however you find a problem, you can
+
+ - [Report this as a bug on GitHub](https://github.com/PrestaShop/PrestaShop/issues) (read [how to report issues](https://devdocs.prestashop.com/1.7/contribute/contribute-reporting-issues/))
+ - Submit a bug fix by creating a [pull request](https://github.com/PrestaShop/PrestaShop/compare) (read the [contribution guidelines](https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/))
+
+## Release Candidate
+
+When Beta period ends, we consider that all the remaining regressions for this release are registered in the Kanban. So the aim is clear: fix them all, then ship.
+
+Once all regressions have been fixed, maintainers deliver a Release Candidate Build using the `.x` branch codebase. This will be the Release Candidate 1 (also known as RC1).
+
+This Build is extensively re-tested by the QA, then provided to everyone. Once released, the timer starts. We wait for one week. During this week we continue testing and exploring the Build, trying to find anything that would not have been detected earlier, and the community should do the same.
+
+By the end of the week, if no new regression has been reported, the RC1 is rebranded and becomes the final release. **The new minor version of PrestaShop is out.**
+
+Most of the time, a couple final regressions will be reported. In that case, the bugs are fixed, an RC2 build is published, and the timer is reset. This cycle repeats until no new regressions are reported within the the defined timeframe.
+
+Finally the latest built Release Candidate becomes the new latest stable PrestaShop software minor release.
+
+## Summary
+
+- The cycle begins when development starts within the scope of a minor version release. When the scope of this version is finished, Feature Freeze is triggered.
+
+Expected duration: 4 months
+
+- Following Feature Freeze, a nightly build is picked up and tested extensively by QA team, who will then report all known defects. This will allow to plan, then deliver a Beta release.
+
+Expected duration: 1 month
+
+- The Beta Build is made available to all. Maintainers host a one-month long beta period to allow the community to test the build and submit feedback.
+
+Expected duration: 1 month
+
+- At the end of the Beta period, all regressions are fixed and maintainers deliver a Release Candidate 1 build.
+If bugs are reported, they are fixed in an RC2 build, and so on until a build has no issues reported within the following week. The last Release Candidate becomes the stable release.
+
+Expected duration: from 1 week (if RC1 is flawless) to 1 month, possibly 2 months
+
+### Calendar
+
+The global duration for all the process is about 6 months. This is why we expect to deliver at most 2 minor releases per year.
+
+
+_(This article was originally published on our blog: [PrestaShop 1.7 Minor Release Lifecycle
+](https://build.prestashop.com/news/ps17-patch-release-lifecycle/))_


### PR DESCRIPTION
I create a new "release" section and put into it the 2 release lifecycle blog posts (adapted with devdoc tone)