### PR TITLE
Add FAQ about overriding the product cover

### DIFF
--- a/src/content/1.7/faq/_index.md
+++ b/src/content/1.7/faq/_index.md
@@ -12,3 +12,5 @@ chapter: true
 This sections aims to becomes the source of truth for the PrestaShop community when it does to questions such as "I want to develop a module X how do I do THIS in PrestaShop"
 
 If someone asked you such a question about PrestaShop and you know the answer please don't send them your answer by email but fill a pull request to complete this section and send them the link to the answer here.
+
+{{% children %}}

--- a/src/content/1.7/faq/product.md
+++ b/src/content/1.7/faq/product.md
@@ -11,8 +11,8 @@ title: Product FAQ
 
 **Q:** How can I override the cover image of my products?
 
-**A:** By default, when a product is displayed in a list its cover image is used, it is configurable in the BackOffice and is set in product properties via the `cover_image_id` property.
-If you want to change this default behaviour you can use the `actionGetProductPropertiesAfter` in your module and change this property.
+**A:** By default, when a product is displayed in a list its cover image is used, it is configurable in the BackOffice and is set in product properties via the `cover_image_id` key.
+If you want to change this default behaviour you can use the `actionGetProductPropertiesAfter` in your module and change this key.
 
 ```php
 /**

--- a/src/content/1.7/faq/product.md
+++ b/src/content/1.7/faq/product.md
@@ -1,0 +1,37 @@
+---
+title: Product FAQ
+---
+
+# Product FAQ
+
+- [Product cover](#product-cover)
+
+## Product cover
+{{< minver v="1.7.7" title="true" >}}
+
+**Q:** How can I override the cover image of my products?
+
+**A:** By default, when a product is displayed in a list its cover image is used, it is configurable in the BackOffice and is set in product properties via the `cover_image_id` property.
+If you want to change this default behaviour you can use the `actionGetProductPropertiesAfter` in your module and change this property.
+
+```php
+/**
+ * Here is an example where we use the first combination image instead of the default cover image,
+ * this is useful when you want to display an image matching your current research for example.
+ */
+public function hookActionGetProductPropertiesAfter($params) {
+    $product = $params['product'];
+    $productInstance = new Product($product['id_product']);
+    $productAttributeId = $product['id_product_attribute'];
+    $combinationImages = $productInstance->getCombinationImages($params['id_lang']);
+    if (empty($combinationImages) || empty($combinationImages[$productAttributeId])) {
+        return;
+    }
+
+    // Update cover image ID to use the first image of the product combination
+    $attributesImages = $combinationImages[$productAttributeId];
+    if (isset($attributesImages[0]['id_image'])) {
+        $params['product']['cover_image_id'] = $attributesImages[0]['id_image'];
+    }
+}
+```

--- a/src/content/1.7/modules/core-updates/1.7.7.md
+++ b/src/content/1.7/modules/core-updates/1.7.7.md
@@ -153,6 +153,10 @@ New hook                       | Function
 A major bug has been fixed in product listing, for products with combinations the image displayed was the first one from the default combination, and the cover was ignored. This behaviour has been fixed but in order to allow modules to override this cover a new `cover_image_id` has been introduced.
 This image ID is then used to populate the `product.cover` field usable in the templates, if you want the default image for the combination (which was the previous behaviour) you can use the new `product.default_image` field.
 
+{{% notice warning %}}
+If your theme overrides some of the `classic` theme templates and uses the `$product.cover` property you should check that it still matches the expected behaviour, especially in the `themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl` used in the product page where `$product.default_image` should be used.
+{{% /notice %}}
+
 {{% notice note %}}
 You can read this FAQ if you want to know [how to override the Product cover]({{< ref "1.7/faq/product#product-cover" >}}).
 {{% /notice %}}

--- a/src/content/1.7/modules/core-updates/1.7.7.md
+++ b/src/content/1.7/modules/core-updates/1.7.7.md
@@ -151,6 +151,7 @@ New hook                       | Function
 ## Product cover
 
 A major bug has been fixed in product listing, for products with combinations the image displayed was the first one from the default combination, and the cover was ignored. This behaviour has been fixed but in order to allow modules to override this cover a new `cover_image_id` has been introduced.
+This image ID is then used to populate the `product.cover` field usable in the templates, if you want the default image for the combination (which was the previous behaviour) you can use the new `product.default_image` field.
 
 {{% notice note %}}
 You can read this FAQ if you want to know [how to override the Product cover]({{< ref "1.7/faq/product#product-cover" >}}).

--- a/src/content/1.7/modules/core-updates/1.7.7.md
+++ b/src/content/1.7/modules/core-updates/1.7.7.md
@@ -148,6 +148,14 @@ New hook                       | Function
 **displayAdminOrderMain**      | It is displayed in the side column (similar to displayAdminOrderMainBottom) but right under the details view
 **actionGetAdminOrderButtons** | It is used to build a collection of buttons in the order thanks to an `ActionsBarButtonsCollection` which is automatically rendered
 
+## Product cover
+
+A major bug has been fixed in product listing, for products with combinations the image displayed was the first one from the default combination, and the cover was ignored. This behaviour has been fixed but in order to allow modules to override this cover a new `cover_image_id` has been introduced.
+
+{{% notice note %}}
+You can read this FAQ if you want to know [how to override the Product cover]({{< ref "1.7/faq/product#product-cover" >}}).
+{{% /notice %}}
+
 ## Other changes
 
 - CLDR `Specification\Number` [is now immutable](https://github.com/PrestaShop/PrestaShop/pull/15755)


### PR DESCRIPTION
In 177 the cover image is used by default in product listing, this explains how to verride this behaviour starting .7.7