### PR TITLE
Adds warning about module console command

### DIFF
--- a/src/content/1.7/modules/concepts/commands.md
+++ b/src/content/1.7/modules/concepts/commands.md
@@ -15,7 +15,8 @@ Since version 1.7 of PrestaShop, everyone have access to the PrestaShop console 
 Since v1.7.5, you can add and provide your own commands into the PrestaShop console using modules.
 
 {{% notice warning %}}
-If you use PrestaShop Core legacy classes, it will not works yet. We will fix it soon.
+If you load and use PrestaShop Core legacy classes such as an ObjectModel within a Command context, you might run into issues. This is a known limitation of the Commands.
+Removing this limitation is being explored for future PS versions.
 {{% /notice %}}
 
 Let's see an example of a really common task when we usually use CRON scripts: you want to export your products into an XML file in order to import them into an another platform (a PIM or an ERP).

--- a/src/content/1.7/modules/concepts/commands.md
+++ b/src/content/1.7/modules/concepts/commands.md
@@ -9,10 +9,14 @@ weight: 10
 Since version 1.7 of PrestaShop, everyone have access to the PrestaShop console using the following instruction in a terminal:
 
 ``
-./bin/console # or ./app/console for PrestaShop < 1.7.3
+./bin/console
 ``
 
 Since v1.7.5, you can add and provide your own commands into the PrestaShop console using modules.
+
+{{% notice warning %}}
+If you use PrestaShop Core legacy classes, it will not works yet. We will fix it soon.
+{{% /notice %}}
 
 Let's see an example of a really common task when we usually use CRON scripts: you want to export your products into an XML file in order to import them into an another platform (a PIM or an ERP).
 


### PR DESCRIPTION
Adds warning about console command from module with usage of legacy classes.
Remove example for PrestaShop < 1.7.3 because it's available only from PrestaShop 1.7.5 for modules.