### PR TITLE
Fix table of contents missing elements

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -36,3 +36,7 @@ markup:
   goldmark:
     renderer:
       unsafe: true
+  tableOfContents:
+    endLevel: 3
+    ordered: false
+    startLevel: 1


### PR DESCRIPTION
By default, Hugo was only adding H3~H4 to the table of contents (levels start at 0 for H1). This change brings back H2 to the ToC.

Before change:
<img width="1330" alt="Screenshot 2020-06-16 at 18 45 50" src="https://user-images.githubusercontent.com/1009343/84803018-afda5a00-b001-11ea-956f-e2d7510bf4e2.png">

After change:
<img width="1343" alt="Screenshot 2020-06-16 at 18 45 55" src="https://user-images.githubusercontent.com/1009343/84803028-b36de100-b001-11ea-8362-c88e74dad175.png">
