### PR TITLE
Rename "Core Development" to "Core Development Reference"

### DIFF
--- a/src/content/1.7/development/_index.md
+++ b/src/content/1.7/development/_index.md
@@ -1,5 +1,6 @@
 ---
-title: Core Development
+title: Core Development Reference
+menuTitle: "Core Reference"
 weight: 2
 pre: "<b>2. </b>"
 chapter: true
@@ -7,7 +8,7 @@ chapter: true
 
 ### Chapter 2
 
-# Core Development
+# Core Development Reference
 
 This section describes technical aspects of the PrestaShop Core.
 


### PR DESCRIPTION
Makes more sense to me this way because it's not only meant for core development