### PR TITLE
Add {{% children %}} in Themes > Reference > Templates

### DIFF
--- a/src/content/1.7/themes/reference/templates/_index.md
+++ b/src/content/1.7/themes/reference/templates/_index.md
@@ -11,3 +11,5 @@ The following section describes the purpose of each template and how to use them
 
 PrestaShop front office is based on Smarty template engine, for this part it's very important
 you understood well how Smarty works, especially [template inheritance]({{< ref "1.7/themes/reference/template-inheritance/_index.md" >}}).
+
+{{% children %}}


### PR DESCRIPTION
Following examples like PrestaShop#581 from @ksaandev 😄

Page without children today: https://devdocs.prestashop.com/1.7/themes/reference/templates/