### PR TITLE
Correct path to load Module twig

### DIFF
--- a/src/content/1.7/modules/concepts/hooks/use-hooks-on-modern-pages.md
+++ b/src/content/1.7/modules/concepts/hooks/use-hooks-on-modern-pages.md
@@ -243,7 +243,7 @@ public function hookDisplayDashboardToolbarIcons($params)
 
         $this->writeFile($productsXml, $filepath);
 
-        return $this->get('twig')->render('@PrestaShop/Foo/download_link.twig',[
+        return $this->get('twig')->render('@Module/Foo/download_link.twig',[
             'filepath' => _PS_BASE_URL_.'/products.xml',
         ]);
     }


### PR DESCRIPTION
As explained in https://www.prestashop.com/forums/topic/1017862-using-twig-tmplate-from-a-module-hook-in-176/?tab=comments#comment-3210727

Twig template are their root path

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Documentation is wrong, generate a 500 
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes {paste the issue here}.
| How to test?  | Follow actual documentation about twig template load from any module.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
