### PR TITLE
Add displayInvoiceLegalFreeText hook in pdf.md

### DIFF
--- a/src/content/1.7/modules/concepts/pdf.md
+++ b/src/content/1.7/modules/concepts/pdf.md
@@ -164,14 +164,15 @@ $hook_name = 'displayPDF' . $template;
 
 #### List of available Hooks
 
-| Concept       | Hook name                 |
-|---------------|---------------------------|
-| Invoice       | displayPDFInvoice         |
-| Delivery Slip | displayPDFDeliverySlip    |
-| Order Return  | displayPDFOrderReturn     |
-| Order Slip    | displayPDFOrderSlip       |
-| Supply Order  | displayPDFSupplyOrderForm |
-| RGPD Archive  | displayPDFPSGDPRModule    |
+| Concept       | Hook name                   |
+|---------------|-----------------------------|
+| Invoice       | displayPDFInvoice           |
+| Invoice       | displayInvoiceLegalFreeText |
+| Delivery Slip | displayPDFDeliverySlip      |
+| Order Return  | displayPDFOrderReturn       |
+| Order Slip    | displayPDFOrderSlip         |
+| Supply Order  | displayPDFSupplyOrderForm   |
+| RGPD Archive  | displayPDFPSGDPRModule      |
 
 ### Minimal Example: add an extra property to the Invoice
 


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add missing displayInvoiceLegalFreeText hook in pdf documentation
| Type?         | bug fix / improvement / new feature / refacto
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes {paste the issue here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
