### PR TITLE
Update kpi-blocks.md

### DIFF
--- a/src/content/1.7/modules/concepts/controllers/kpi-blocks.md
+++ b/src/content/1.7/modules/concepts/controllers/kpi-blocks.md
@@ -31,6 +31,7 @@ You can follow these steps to easily add a KPI row to a modern page:
     {{% /notice %}}
 
 * Build the KPI row in your controller's action and assign it to twig by returning it:
+
     ```php
     <?php
     public function showSettingsAction(Request $request)

--- a/src/content/1.7/modules/concepts/controllers/kpi-blocks.md
+++ b/src/content/1.7/modules/concepts/controllers/kpi-blocks.md
@@ -32,7 +32,7 @@ You can follow these steps to easily add a KPI row to a modern page:
 
 * Build the KPI row in your controller's action and assign it to twig by returning it:
     ```php
-<?php
+    <?php
     public function showSettingsAction(Request $request)
     {
         // Create the KPI row factory service


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | The KPI page is currently pretty messed up because the code under the text "Build the KPI row in your controller’s action and assign it to twig by returning it:" is not showing in the code block. It currently looks like this:
| ![image](https://user-images.githubusercontent.com/8537829/87154802-21808d80-c2ba-11ea-9291-cbb5c55b42b2.png)
| Type         | improvement
| BC breaks    | no
| Deprecations | no
| How to test  | This can be tested by checking if the code under "Build the KPI row in your controller’s action and assign it to twig by returning it:" is in the codeblock and not outside it like it currently it.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
