### PR TITLE
Include H4 in Table of contents

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -37,6 +37,6 @@ markup:
     renderer:
       unsafe: true
   tableOfContents:
-    endLevel: 3
+    endLevel: 4
     ordered: false
     startLevel: 1


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Include headers up to H4 in ToC (instead of up to H3)
| Fixed ticket? | ~

Before:
<img width="279" alt="Screenshot 2020-07-10 at 18 25 25" src="https://user-images.githubusercontent.com/1009343/87176876-02debe80-c2db-11ea-8396-344dd95c0f99.png">

After:
<img width="276" alt="Screenshot 2020-07-10 at 18 25 00" src="https://user-images.githubusercontent.com/1009343/87176889-070adc00-c2db-11ea-98d0-e1e98a46625e.png">
