### PR TITLE
Add missing extension to upgrade documentation

### DIFF
--- a/src/content/1.7/modules/creation/enabling-auto-update.md
+++ b/src/content/1.7/modules/creation/enabling-auto-update.md
@@ -157,7 +157,7 @@ Since the version that you are planning to update to is 1.1.0, the first thing w
 
 ```php
 <?php
-// File: /upgrade/upgrade-1.1.0
+// File: /upgrade/upgrade-1.1.0.php
 
 if (!defined('_PS_VERSION_')) {
     exit;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | A `.php` extension was missing in the documentation.
| Type?         | Documentation fix