### PR TITLE
Change jquery to v3 instead of v2

### DIFF
--- a/src/content/1.7/themes/getting-started/asset-management/_index.md
+++ b/src/content/1.7/themes/getting-started/asset-management/_index.md
@@ -170,7 +170,7 @@ Every page of every theme loads the following files:
 <td align="left">core.js</td>
 <td align="left">corejs</td>
 <td align="left">0</td>
-<td align="left">Provided by PrestaShop. Contains Jquery3, dispatches PrestaShop events and holds PrestaShop logic.</td>
+<td align="left">Provided by PrestaShop. Contains jQuery3, dispatches PrestaShop events and holds PrestaShop logic.</td>
 </tr>
 <tr class="even">
 <td align="left">theme.js</td>

--- a/src/content/1.7/themes/getting-started/asset-management/_index.md
+++ b/src/content/1.7/themes/getting-started/asset-management/_index.md
@@ -170,7 +170,7 @@ Every page of every theme loads the following files:
 <td align="left">core.js</td>
 <td align="left">corejs</td>
 <td align="left">0</td>
-<td align="left">Provided by PrestaShop. Contains Jquery2, dispatches PrestaShop events and holds PrestaShop logic.</td>
+<td align="left">Provided by PrestaShop. Contains Jquery3, dispatches PrestaShop events and holds PrestaShop logic.</td>
 </tr>
 <tr class="even">
 <td align="left">theme.js</td>

--- a/src/content/1.7/themes/reference/javascript-events/_index.md
+++ b/src/content/1.7/themes/reference/javascript-events/_index.md
@@ -20,7 +20,7 @@ A default store loads a lot less files in 1.7 compared to 1.6, there are no spec
 
   File      | Content
   ----------| ------------------------------------------------------------------------------
-  `core.js` | Loads jQuery2, makes ajax calls, defines core methods that all frontend should use
+  `core.js` | Loads jQuery3, makes ajax calls, defines core methods that all frontend should use
   `theme.js`| Bundles all theme specific code and libraries
 
 {{% notice tip %}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | It was saying that we use jquery v2 instead of v3
| Fixed ticket? | Fixes #553

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
