### PR TITLE
Fix broken link in Smarty extensions page

### DIFF
--- a/src/content/1.7/development/components/smarty-extensions/_index.md
+++ b/src/content/1.7/development/components/smarty-extensions/_index.md
@@ -55,7 +55,7 @@ You can choose to exclude some modules, which won't be notified of the hook:
 
 ### {l}
 
-The `{l}` function allows you to insert translated text in your template using the [Translation system]({{ ref "/1.7/development/internationalization/translation/_index.md" >}}).
+The `{l}` function allows you to insert translated text in your template using the [Translation system]({{< ref "/1.7/development/internationalization/translation/_index.md" >}}).
 
 This function takes the following of arguments:
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix the broken link to the Translation page, in the Smarty extensions page (in the description of the {l} Smarty function).
| Fixed ticket? | No

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
