### PR TITLE
The Webservice key must have a length of 32 characters

### DIFF
--- a/src/content/1.7/webservice/tutorials/creating-access.md
+++ b/src/content/1.7/webservice/tutorials/creating-access.md
@@ -65,7 +65,7 @@ Creating API keys can be done with the class WebserviceKey.
 ```php
 <?php
 $apiAccess = new WebserviceKey();
-$apiAccess->key = 'GENERATE_A_COMPLEX_VALUE';
+$apiAccess->key = 'GENERATE_A_COMPLEX_VALUE_32_CHAR';
 $apiAccess->save();
 ```
 

--- a/src/content/1.7/webservice/tutorials/creating-access.md
+++ b/src/content/1.7/webservice/tutorials/creating-access.md
@@ -65,7 +65,7 @@ Creating API keys can be done with the class WebserviceKey.
 ```php
 <?php
 $apiAccess = new WebserviceKey();
-$apiAccess->key = 'GENERATE_A_COMPLEX_VALUE_32_CHAR';
+$apiAccess->key = 'GENERATE_A_COMPLEX_VALUE_WITH_32_CHARACTERS';
 $apiAccess->save();
 ```
 


### PR DESCRIPTION
Key length is checked to be 32 chars long so hinting that would be nice.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Made example code more specific to prevent errors.
| Fixed ticket? | No

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
