### PR TITLE
Missing close parentheses

### DIFF
--- a/src/content/1.7/modules/concepts/controllers/front-controllers.md
+++ b/src/content/1.7/modules/concepts/controllers/front-controllers.md
@@ -157,7 +157,7 @@ Context::getContext()->link->getModuleLink('cheque', 'validation', array('idPaym
 When you call controller via AJAX, you nedd to add `ajax` parameter in the url.
 
 ```php
-Context::getContext()->link->getModuleLink('cheque', 'validation', array('idPayment' => 1337, 'ajax'=>true);
+Context::getContext()->link->getModuleLink('cheque', 'validation', array('idPayment' => 1337, 'ajax'=>true));
 ```
 
 * Without URL rewriting: `http://<shop_domain>/index.php?idPayment=1337&fc=module&module=cheque&controller=validation&id_lang=1&ajax=true`


### PR DESCRIPTION
The code snippet for creating a module link for AJAX was missing a parentheses at the end of the line

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
