### PR TITLE
Fix incorrect terms usage. Сlarify using `dump()`.

### DIFF
--- a/src/content/1.7/basics/installation/configuration.md
+++ b/src/content/1.7/basics/installation/configuration.md
@@ -32,15 +32,15 @@ You, on the other hand, need this information in order to correct any potential 
 define('_PS_MODE_DEV_', true);
 ```
 
-## Using the dump() method
+## Using the dump() function
 
-These two methods enable you to check for the state of a given variable at a specific place within your code.
+These two functions enable you to check for the state of a given variable at a specific place within your code.
 
-PrestaShop used to have custom debug methods available for developers: `p($variable)` and `d($variable)`. They were used to display the content of a variable, and were really a wrapper around the well-known `print_r()` method. On top of that, PrestaShop had the `ppp()` and `ddd()` methods, which were respectively the aliases of `p()` and `d()`; and the various `fd()`, `epr()` and `dieObject()` methods.
+PrestaShop used to have custom debug functions available for developers: `p($variable)` and `d($variable)`. They were used to display the content of a variable, and were really a wrapper around the well-known `print_r()` method. On top of that, PrestaShop had the `ppp()` and `ddd()` functions, which were respectively the aliases of `p()` and `d()`; and the various `fd()`, `epr()` and `dieObject()` functions.
 
-All of this has changed with PrestaShop 1.7: we now rely solely on [Symfony's VarDumper::dump()](https://symfony.com/doc/current/components/var_dumper.html#the-dump-function) function. You can now rely on a single method instead of having multiple debug functions. The dump() function is very powerful, and is always available on output (even without `die()`). Moreover, you can use it in your console scripts because this function also has a formatter in CLI mode.
+All of this has changed with PrestaShop 1.7: we now rely solely on [Symfony VarDumper's dump()](https://symfony.com/doc/current/components/var_dumper.html#the-dump-function) function. You can now rely on a single function instead of having multiple debug functions. The dump() function is very powerful, and is always available on output (even without `die()`). Moreover, you can use it in your console scripts because this function also has a formatter in CLI mode.
 
-The `dump()` method is not activated by default. To activate it, you must enable the Debug mode, by setting `_PS_MODE_DEV_` to `true` (see above).
+The `dump()` function is not activated by default. To activate it, you must enable the Debug mode, by setting `_PS_MODE_DEV_` to `true` (see above).
 
 ## Enabling the multistore mode
 


### PR DESCRIPTION
1. Fix incorrect use of terms `function` and `method`. Functions - without classes. Methods - with classes.
2. Сlarify using `dump()` function. In code we call [dump()](https://github.com/symfony/var-dumper/blob/master/Resources/functions/dump.php#L18) function, but not [VarDumper::dump()](https://github.com/symfony/var-dumper/blob/master/VarDumper.php#L37) method.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |1. Fix incorrect use of terms `function` and `method`. Functions - without classes. Methods - with classes. <br/>2. Сlarify using `dump()` function. In code we call [dump()](https://github.com/symfony/var-dumper/blob/master/Resources/functions/dump.php#L18) function, but not [VarDumper::dump()](https://github.com/symfony/var-dumper/blob/master/VarDumper.php#L37) method.
| Fixed ticket? | No

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
