### PR TITLE
Allow installation of Hugo's mac os version via install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Contributions are more than welcome! [Find out how](https://devdocs.prestashop.c
 
 TL;DR:
 
-* **Linux**: `./bin/installHugo.sh`
-* **Mac**: `brew install hugo`
+* **Mac and Linux**: `./bin/installHugo.sh`
 * **Windows**: Grab the [release binary](https://github.com/gohugoio/hugo/releases)
 
 Or read the [Official install guide](https://gohugo.io/getting-started/installing).

--- a/bin/installHugo.sh
+++ b/bin/installHugo.sh
@@ -3,15 +3,13 @@ set -euo pipefail
 
 export HUGO_VERSION="0.72.0"
 
-if [ `uname` = "Linux" ]
-then
-	export HUGO_OS="Linux-64bit"
-elif [ `uname` = "Darwin" ]
-then
+if [ `uname` = "Linux" ]; then
+    export HUGO_OS="Linux-64bit"
+elif [ `uname` = "Darwin" ]; then
     export HUGO_OS="macOS-64bit"
 else
-	echo 'This script only works on Linux and Mac os'
-	exit 1
+    echo 'This script only works on Linux and Mac os'
+    exit 1
 fi
 
 cd "$( dirname "$0" )/../" && pwd

--- a/bin/installHugo.sh
+++ b/bin/installHugo.sh
@@ -3,9 +3,21 @@ set -euo pipefail
 
 export HUGO_VERSION="0.72.0"
 
+if [ `uname` = "Linux" ]
+then
+	export HUGO_OS="Linux-64bit"
+elif [ `uname` = "Darwin" ]
+then
+    export HUGO_OS="macOS-64bit"
+else
+	echo 'This script only works on Linux and Mac os'
+	exit 1
+fi
+
 cd "$( dirname "$0" )/../" && pwd
 
-wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_${HUGO_OS}.tar.gz
+
 rm -rf hugo
-tar -xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz hugo
-rm hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+tar -xzf hugo_${HUGO_VERSION}_${HUGO_OS}.tar.gz hugo
+rm hugo_${HUGO_VERSION}_${HUGO_OS}.tar.gz


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | On mac os, hugo should be installed via the installation script instead of brew, so that everyone use the same version.
| Fixed ticket? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
