### PR TITLE
Declare strict types don't apply on interfaces

### DIFF
--- a/src/content/1.7/development/coding-standards/_index.md
+++ b/src/content/1.7/development/coding-standards/_index.md
@@ -45,7 +45,7 @@ The prestashop specific configuration file [can be found here](https://github.co
 
 Starting on 1.7.7, all new PHP code should be strictly typed.
 
-This means that all new methods **must** specify a type for all parameters as well as the return type. Similarly, all new classes must enforce type strictness via `declare`:
+This means that all new methods **must** specify a type for all parameters as well as the return type. Similarly, all new classes except interfaces must enforce type strictness via `declare`:
 
 ```php
 <?php


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Declare strict types don't apply on interfaces
| Fixed ticket? | None

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
