### PR TITLE
Method called twice in work with search form page

### DIFF
--- a/src/content/1.7/development/components/grid/tutorials/work-with-search-form/_index.md
+++ b/src/content/1.7/development/components/grid/tutorials/work-with-search-form/_index.md
@@ -71,7 +71,6 @@ final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFact
                     ],
                     'redirect_route' => 'admin_manufacturers_index',
                 ])
-                ->setAssociatedColumn('actions')
             )
         ;
     }
@@ -290,7 +289,6 @@ It is defined in the [`SearchAndResetType` options]({{< ref "/1.7/development/co
                     ],
                     'redirect_route' => 'admin_manufacturers_index',
                 ])
-                ->setAssociatedColumn('actions')
             )
     ...
 ```


### PR DESCRIPTION
double method call

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
