### PR TITLE
Method called twice in filter type reference page

### DIFF
--- a/src/content/1.7/development/components/grid/filter-types-reference/_index.md
+++ b/src/content/1.7/development/components/grid/filter-types-reference/_index.md
@@ -147,7 +147,6 @@ class MyGridDefinitionFactory extends AbstractGridDefinition
                             ],
                             'redirect_route' => 'admin_monitorings_index',
                         ])
-                        ->setAssociatedColumn('actions')
                 );
         }
 }


### PR DESCRIPTION
a double call of the method

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
