### PR TITLE
Fix Twitter meta image URL path

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -21,7 +21,7 @@ params:
     gitHub: "https://github.com/PrestaShop/PrestaShop/"
     reportBug: "https://github.com/PrestaShop/PrestaShop/issues"
     slack: "https://github.com/PrestaShop/open-source/blob/master/slack/readme.md"
-  coverImage: "/1.7/twitter-cover.jpg"
+  coverImage: "1.7/twitter-cover.jpg"
 
 # For search functionality
 outputs:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove double slash from `.Site.Params.coverImage` Hugo variable . This should fix this double slash:<br/>`<meta property="og:image" content="https://devdocs.prestashop.com//1.7/twitter-cover.jpg" />`<br/>⬇️ <br/>`<meta property="og:image" content="https://devdocs.prestashop.com/1.7/twitter-cover.jpg" />`<br/>
| Fixed issue? | https://cards-dev.twitter.com/validator does not correctly displays Twitter Card for https://devdocs.prestashop.com/1.7/project/maintainers-guide/how-to-become-a-maintainer/

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
