### PR TITLE
Fix class name ChoiceCategoriesTreeType

### DIFF
--- a/src/content/1.7/development/architecture/migration-guide/forms/_index.md
+++ b/src/content/1.7/development/architecture/migration-guide/forms/_index.md
@@ -53,7 +53,7 @@ Form types must be created in the `src/PrestaShopBundle/Form/Admin/{Menu}/{Page}
 
 PrestaShop provides some built-in Form types that will help you integrate the specific form components PrestaShop uses in the Back Office. You'll find them inside the *Types* folder:
 
-* `ChoiceCategoryTreeType`
+* `ChoiceCategoriesTreeType`
 * `CustomMoneyType`
 * `DatePickerType`
 * `TextWithUnitType`


### PR DESCRIPTION
Fixed an error in the class name, correct ChoiceCategoriesTreeType, instead of ChoiceCategoryTreeType

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
