### PR TITLE
Mention jQuery.attr has changed in 1.7.7

### DIFF
--- a/src/content/1.7/modules/core-updates/1.7.7.md
+++ b/src/content/1.7/modules/core-updates/1.7.7.md
@@ -118,7 +118,7 @@ Modules relying on these old capabilities may experience problems, including but
 
 * `context` property has been removed
 * Using `dataType` in an ajax request won't trigger the `success` / `done` methods if the type of content returned does not match
-* `jQuery.attr()` behavior has evolved, `jQuery.prop()` should be used instead
+* [`jQuery.attr()` behavior has evolved](https://api.jquery.com/attr/), most of the time, you should use `jQuery.prop()` instead. 
 
 
 ## Order view page layout modifications

--- a/src/content/1.7/modules/core-updates/1.7.7.md
+++ b/src/content/1.7/modules/core-updates/1.7.7.md
@@ -112,10 +112,13 @@ Because of this, the size for some indexes have been reduced to `191`:
 
 jQuery has been updated to 3.4.1 in Back office (up from 1.11 in legacy pages) and Core theme (up from 2.1.4).
 
-Although backwards compatibility is provided by [jquery migrate](https://github.com/jquery/jquery-migrate), some modules may experience problems, including but not limited to:
+**jQuery has changed a lot between v1.11 / v2.1.4 and v3.4.1. This is why [jquery migrate](https://github.com/jquery/jquery-migrate) was enabled in order to provide a layer of compatibility, but this does not preserve all jQuery capabilities for such old versions.**
 
-* `context` property has been removed,
-* Using `dataType` in an ajax request won't trigger the `success` / `done` methods if the type of content returned does not match.
+Modules relying on these old capabilities may experience problems, including but not limited to:
+
+* `context` property has been removed
+* Using `dataType` in an ajax request won't trigger the `success` / `done` methods if the type of content returned does not match
+* `jQuery.attr()` behavior has evolved, `jQuery.prop()` should be used instead
 
 
 ## Order view page layout modifications


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Mention jQuery.attr has changed in 1.7.7 and jQuery.prop should be used instead

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
