### PR TITLE
Add children tag into modules/concepts/templating

### DIFF
--- a/src/content/1.7/modules/concepts/templating/_index.md
+++ b/src/content/1.7/modules/concepts/templating/_index.md
@@ -5,3 +5,5 @@ chapter: true
 ---
 
 # Templates
+
+{{% children %}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The `1.7/modules/concepts/templating/` page is missing a children tag : https://devdocs.prestashop.com/1.7/modules/concepts/templating/
| Fixed ticket? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
