### PR TITLE
Wrong path on overrading templates

### DIFF
--- a/src/content/1.7/modules/concepts/templating/admin-views.md
+++ b/src/content/1.7/modules/concepts/templating/admin-views.md
@@ -23,7 +23,7 @@ Our Customer want a better Listing view: the "Price" column should be at positio
 
 ### Identify the template to override
 
-First we need to identify which Twig template(s) is (are) rendered. Using the *Debug mode*, select the "Twig metrics" block in the Symfony Debug toolbar. You'll see the list of Twig templates used to render the page. In our case, we are interested in the template "**@PrestaShop/Admin/Product/catalog.html.twig**".
+First we need to identify which Twig template(s) is (are) rendered. Using the *Debug mode*, select the "Twig metrics" block in the Symfony Debug toolbar. You'll see the list of Twig templates used to render the page. In our case, we are interested in the template "**@PrestaShop/Admin/Product/CatalogPage/catalog.html.twig**".
 
 ### Override the template in the module: a simple "Hello world!"
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In the "Identify the template to override" section, there was an error since the path didn't include the CatalogPage folder which could be very confusing because the other paths in the guide are well formed.
| Fixed ticket? | No, as far as I know.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
