### PR TITLE
how to access to service container in module

### DIFF
--- a/src/content/1.7/modules/concepts/services/_index.md
+++ b/src/content/1.7/modules/concepts/services/_index.md
@@ -209,7 +209,7 @@ class yourmodule {
     {
         ...
         // The controller here is the ADMIN one so only admin services are accessible
-        $yourService = $this->context->controller->getContainer()->get('your_company.your_module.admin.your_service');
+        $yourService = $this->get('your_company.your_module.admin.your_service');
         ...
     }
 
@@ -217,7 +217,7 @@ class yourmodule {
     {
         ...
         // The controller here is the FRONT one so only front services are accessible
-        $yourService = $this->context->controller->getContainer()->get('your_company.your_module.front.your_service');
+        $yourService = $this->get('your_company.your_module.front.your_service');
         ...
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| How to access to the service container from module? | User public method  `get()`

Old code `$this->context->controller->getContainer()` is not correct.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
