### PR TITLE
Add MySQL MariaDB requirements

### DIFF
--- a/src/content/1.7/basics/installation/system-requirements.md
+++ b/src/content/1.7/basics/installation/system-requirements.md
@@ -226,3 +226,52 @@ extension = php_gd2.dll
 allow_url_fopen = On
 allow_url_include = Off
 ```
+
+## MySQL / MariaDB requirements
+
+### MySQL / MariaDB compatibility chart
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th colspan="2" style="text-align:center">MySQL Version</th>
+      <th colspan="2" style="text-align:center">MariaDB Version</th>
+    </tr>
+    <tr class="h-version-titles">
+      <th>PrestaShop Version</th>
+      <th>&le;&nbsp;5.6</th>
+      <th>&ge;&nbsp;5.7</th>
+      <th>&le;&nbsp;10.1</th>
+      <th>&ge;&nbsp;10.2</th>
+    </tr>
+  </thead>
+<tbody>
+  <tr>
+    <td>&le;&nbsp;1.7.6</td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes">
+      <i class="fa fa-check" aria-hidden="true" title="Recommended version"></i>
+      <span class="sr-only">Recommended version</span>
+    </td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes">
+      <i class="fa fa-check" aria-hidden="true" title="Recommended version"></i>
+      <span class="sr-only">Recommended version</span>
+    </td>
+  </tr>
+  <tr>
+    <td>&ge;&nbsp;1.7.7</td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-yes">
+      <i class="fa fa-check" aria-hidden="true" title="Recommended version"></i>
+      <span class="sr-only">Recommended version</span>
+    </td>
+    <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-yes">
+      <i class="fa fa-check" aria-hidden="true" title="Recommended version"></i>
+      <span class="sr-only">Recommended version</span>
+    </td>
+  </tr>
+</tbody>
+</table>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Answer to issues installing or upgrading Prestashop 1.7.7 using MySQL < 5.7 or MariaDB < 10.2. I suggest add database requirements with a beautiful chart as like as PHP one.
| Fixed ticket? | Answer #22809 #22960 and #21948 related issues

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
