### PR TITLE
Fix error in executeS return description and add a notice

### DIFF
--- a/src/content/1.7/development/database/db.md
+++ b/src/content/1.7/development/database/db.md
@@ -32,7 +32,8 @@ $result = $db->executeS($request);
 
 As the method deals with raw SQL requests, the `_DB_PREFIX_` must be used.
 
-The result is an associative array, containing an array for each row.
+The result is an array of associative arrays, containing an array for each row.
+It should only be used for read only queries: SELECT, SHOW, etc.
 
 ### Execute a raw SQL request (SELECT only) and get the first row
 


### PR DESCRIPTION
- executeS return an array of associative arrays
- add a notice to use it only for read queries

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
