### PR TITLE
Fix link to testing introduction

### DIFF
--- a/src/content/1.7/contribute/contribute-pull-requests/contribute_using_docker.md
+++ b/src/content/1.7/contribute/contribute-pull-requests/contribute_using_docker.md
@@ -98,7 +98,7 @@ A good practice is to write meaningful commits messages: it's better to have "co
 ### Launch the test suite
 
 Your changes now sounds ok, and you're almost ready to share your changes with the community.
-Before all, you may ensure your changes don't break everything: this is why we have multiple test suites you can use. Want to read more about tests in PrestaShop? Head to [this]({{< ref "1.7/testing/introduction.md" >}} page.
+Before all, you may ensure your changes don't break everything: this is why we have multiple test suites you can use. Want to read more about tests in PrestaShop? Head to [this]({{< ref "1.7/testing/introduction.md" >}}) page.
 
 You can execute it in your dockerized PrestaShop application without altering your website (it uses a specific database).
 


### PR DESCRIPTION
Added the missing end parenthesis.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The markdown link was missing the end parenthesis so it bled into the page.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
