### PR TITLE
Introduce Header-Stamp in modules CI

### DIFF
--- a/src/content/1.7/modules/testing/basic-checks.md
+++ b/src/content/1.7/modules/testing/basic-checks.md
@@ -93,26 +93,27 @@ When the extension is open-source, sharing the license is one important task.
 
 [Header-Stamp](https://github.com/PrestaShopCorp/header-stamp) is a tool that applies a header on all compatible files (PHP, JS...).
 In these headers, details can be found about the author, the license, the original year of publication.
-Everytime there is a change to make, one command would apply it to all your files.
+One command will apply the license header to all your files, or update it as necessary.
 
 This tool is part of `prestashop/php-dev-tools` available on [Packagist](https://packagist.org/packages/prestashop/php-dev-tools), which can be required via composer.
 
-As an example, the license AFL is going to be applied on a PrestaShop native module. There is a AFL template existing in the package that can be used,
-and there are a few folders to ignore while these changes are applied (`vendor` because libraries have their own license, `test` and `_dev` because they
-won't be part of the release package).
+### Example
 
-Commands to install and use the tool would be:
+In the following example, the AFL license is going to be applied on a module. 
+
+The Header-Stamp package already includes an AFL template, so we can use that one. We also have a few folders that we will want to ignore: `vendor` (because libraries have their own license), `test`, and `_dev` (because they won't be part of the release package).
+
+To install and use the tool:
 
 ```bash
-# Install dependencies
+# Install header-stamp
 composer require --dev prestashop/php-dev-tools
 
 # Apply header block
 php vendor/bin/header-stamp --license=vendor/prestashop/header-stamp/assets/afl.txt --exclude=vendor,tests,_dev
 ```
 
-To return the list of files that would be updated because their header block is missing or different from the one to apply, use the
-`--dry-run` parameter.
+To return the list of files that would be updated because their header block is missing or different from the one to apply, use the `--dry-run` parameter:
 
 ```bash
 php vendor/bin/header-stamp --license=vendor/prestashop/header-stamp/assets/afl.txt --exclude=vendor,tests,_dev --dry-run

--- a/src/content/1.7/modules/testing/basic-checks.md
+++ b/src/content/1.7/modules/testing/basic-checks.md
@@ -86,3 +86,34 @@ Using cache file ".php_cs.cache".
 
 Checked all files in 0.085 seconds, 12.000 MB memory used
 ```
+
+## License headers
+
+When the extension is open-source, sharing the license is one important task.
+
+[Header-Stamp](https://github.com/PrestaShopCorp/header-stamp) is a tool that applies a header on all compatible files (PHP, JS...).
+In these headers, details can be found about the author, the license, the original year of publication.
+Everytime there is a change to make, one command would apply it to all your files.
+
+This tool is part of `prestashop/php-dev-tools` available on [Packagist](https://packagist.org/packages/prestashop/php-dev-tools), which can be required via composer.
+
+As an example, the license AFL is going to be applied on a PrestaShop native module. There is a AFL template existing in the lib that can be used,
+and there are a few folder to ignore while these changes are applied (`vendor` because libraries have their own license, test & _dev because they
+won't be part of the release package).
+
+Commands to install and use the tool would be:
+
+```bash
+# Install dependencies
+composer require --dev prestashop/php-dev-tools
+
+# Apply header block
+php vendor/bin/header-stamp --license=vendor/prestashop/header-stamp/assets/afl.txt --exclude=vendor,tests,_dev
+```
+
+To return the list of files that would be updated because their header block is missing or different from the one to apply, use the
+`--dry-run` parameter.
+
+```bash
+php vendor/bin/header-stamp --license=vendor/prestashop/header-stamp/assets/afl.txt --exclude=vendor,tests,_dev --dry-run
+```

--- a/src/content/1.7/modules/testing/basic-checks.md
+++ b/src/content/1.7/modules/testing/basic-checks.md
@@ -97,8 +97,8 @@ Everytime there is a change to make, one command would apply it to all your file
 
 This tool is part of `prestashop/php-dev-tools` available on [Packagist](https://packagist.org/packages/prestashop/php-dev-tools), which can be required via composer.
 
-As an example, the license AFL is going to be applied on a PrestaShop native module. There is a AFL template existing in the lib that can be used,
-and there are a few folder to ignore while these changes are applied (`vendor` because libraries have their own license, test & _dev because they
+As an example, the license AFL is going to be applied on a PrestaShop native module. There is a AFL template existing in the package that can be used,
+and there are a few folders to ignore while these changes are applied (`vendor` because libraries have their own license, `test` and `_dev` because they
 won't be part of the release package).
 
 Commands to install and use the tool would be:

--- a/src/content/1.7/modules/testing/ci-cd.md
+++ b/src/content/1.7/modules/testing/ci-cd.md
@@ -83,6 +83,30 @@ jobs:
       # This tool is outside the composer.json because of the compatibility with PHP 5.6
       - name : Run PHPStan
         run: docker run --rm --volumes-from temp-ps -v $PWD:/web/module -e _PS_ROOT_DIR_=/var/www/html --workdir=/web/module phpstan/phpstan:0.12 analyse --configuration=/web/module/tests/phpstan/phpstan.neon
+
+  header-stamp:
+    name: Check license headers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache vendor folder
+        uses: actions/cache@v1
+        with:
+          path: vendor
+          key: php-${{ hashFiles('composer.lock') }}
+
+      - name: Cache composer folder
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache
+          key: php-composer-cache
+
+      - run: composer install
+
+      - name: Run Header Stamp in Dry Run mode
+        run: php vendor/bin/header-stamp --license=vendor/prestashop/header-stamp/assets/afl.txt --exclude=vendor,tests,_dev --dry-run
 ```
 
 ### Build module artifact


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Header stamp is an updater of all header blocks in a given project, useful to apply the license in an extension. This PR introduces it and explain how to integrate it.
| Fixed ticket? | Fixes https://github.com/PrestaShop/php-dev-tools/issues/25