### PR TITLE
mod argument requires single quotes

### DIFF
--- a/src/content/1.7/modules/creation/module-translation/classic-system.md
+++ b/src/content/1.7/modules/creation/module-translation/classic-system.md
@@ -130,6 +130,10 @@ For instance, translating the string "Welcome to this page!" can be done like th
 {l s='Welcome to this page!' mod='mymodule'}
 ```
 
+{{% notice info %}}
+The `mod` argument value must go with simple quotes. Double quotes are not recognized.
+{{% /notice %}}
+
 In our sample module, the `mymodule.tpl` file...
 
 ```html


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | It took me an hour to realize that my strings were not recognized by the translation system because I used double quotes.
| Fixed ticket? | No

If we write `{l s='Welcome to this page!' mod="mymodule"}` then this string can not be translated because double quotes are not recognized.