### PR TITLE
Fix module send example directory

### DIFF
--- a/src/content/1.7/development/mail.md
+++ b/src/content/1.7/development/mail.md
@@ -78,7 +78,7 @@ class mymodulemycontrollerModuleFrontController extends ModuleFrontController
             NULL,  //from name
             NULL, //file attachment
             NULL, //mode smtp
-            '/modules/yourmodulename/mails' //custom template path
+            _PS_MODULE_DIR_.'yourmodulename/mails' //custom template path
         );
     }
 }

--- a/src/content/1.7/development/mail.md
+++ b/src/content/1.7/development/mail.md
@@ -78,7 +78,7 @@ class mymodulemycontrollerModuleFrontController extends ModuleFrontController
             NULL,  //from name
             NULL, //file attachment
             NULL, //mode smtp
-            _PS_MODULE_DIR_.'yourmodulename/mails' //custom template path
+            _PS_MODULE_DIR_ . 'yourmodulename/mails' //custom template path
         );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The example code to send email from module in the documentation is not working  see : <br />https://www.prestashop.com/forums/topic/1044177-erreur-le-mod%C3%A8le-de-mail-suivant-nexiste-pas-process_atelier/   <br />adding  _PS_MODULE_DIR_ fix the issue
| Fixed ticket? | Non

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
