### PR TITLE
Add `table_label` option in `MaterialMultipleChoiceTableType`

### DIFF
--- a/src/content/1.7/development/components/form/types-reference/material-multiple-choice-table.md
+++ b/src/content/1.7/development/components/form/types-reference/material-multiple-choice-table.md
@@ -16,6 +16,8 @@ but it allows using multiple checkboxes per row. Requires Javascript component t
 | scrollable         | bool  | true          | Whether to make table scrollable or not                                                                                                                                                                                                                    |
 | headers_to_disable | array | []            | Array of header names to be disabled if needed |
 | headers_fixed      | bool  | true          | Whether to make table header fixed or not on scroll (since 1.7.8.x) |
+| table_label      | bool & array  | false          | Set table label (since 1.7.8.x) |
+
 
 ## Required Javascript components
 | Component                                                            | Description                         |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add table_label option Introduced [here](https://github.com/PrestaShop/PrestaShop/pull/21653/files#diff-8a7c28222a77e0e8136ee1d64919a135369ea93aa6def09f0f1a16a94882df8fR120).
| Fixed ticket? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
