### PR TITLE
Add details about actionOrderStatusPostUpdate

### DIFF
--- a/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
+++ b/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
@@ -823,9 +823,8 @@ actionOrderStatusPostUpdate
     Called after the status of an order changes.
     
     {{% notice tip %}}
-	This hook is fired BEFORE the new OrderStatus is saved into the database,  
-	if you need to register after this insertion,  
-	use `actionOrderHistoryAddAfter` or `actionObjectOrderHistoryAddAfter` instead
+	This hook is fired BEFORE the new OrderStatus is saved into the database.
+	If you need to register after this insertion, use `actionOrderHistoryAddAfter` or `actionObjectOrderHistoryAddAfter` instead.
     {{% /notice %}}
 
     Located in: /classes/order/OrderHistory.php

--- a/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
+++ b/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
@@ -821,6 +821,12 @@ WARNING: only invoked when a product is actually removed from an order.
 actionOrderStatusPostUpdate
 : 
     Called after the status of an order changes.
+    
+    {{% notice tip %}}
+	This hook is fired BEFORE the new OrderStatus is saved into the database,  
+	if you need to register after this insertion,  
+	use `actionOrderHistoryAddAfter` or `actionObjectOrderHistoryAddAfter` instead
+    {{% /notice %}}
 
     Located in: /classes/order/OrderHistory.php
 


### PR DESCRIPTION
Related to 

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Inconsistency exists into the `actionOrderStatusPostUpdate` which is fired BEFORE the `OrderStatus` is saved into the database. See my comment on issue here
| Fixed ticket? | This does not fix issue but will prevent issues like PrestaShop/PrestaShop#20772 and PrestaShop/PrestaShop#22218 to be created

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
