### PR TITLE
Fix `actionOrderStatusPostUpdate` notice tips

### DIFF
--- a/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
+++ b/src/content/1.7/modules/concepts/hooks/list-of-hooks.md
@@ -828,7 +828,6 @@ WARNING: only invoked when a product is actually removed from an order.
 actionOrderStatusPostUpdate
 : 
     Called after the status of an order changes.
-    
     {{% notice tip %}}
 	This hook is fired BEFORE the new OrderStatus is saved into the database.
 	If you need to register after this insertion, use `actionOrderHistoryAddAfter` or `actionObjectOrderHistoryAddAfter` instead.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix `actionOrderStatusPostUpdate` notice tips here https://devdocs.prestashop.com/1.7/modules/concepts/hooks/list-of-hooks/#full-list
| Fixed ticket? | N/A

### After

![image](https://user-images.githubusercontent.com/16455155/113730457-3464a900-96f8-11eb-99b7-ef0093041bc5.png)


### Before

![image](https://user-images.githubusercontent.com/16455155/113730699-6544de00-96f8-11eb-8736-86878477f764.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
