### PR TITLE
Add `notice warning` about default `database prefix`

### DIFF
--- a/src/content/1.7/development/database/_index.md
+++ b/src/content/1.7/development/database/_index.md
@@ -9,6 +9,13 @@ weight: 30
 
 By default, PrestaShop’s database tables start with the `ps_` prefix. This can be customized during installation
 
+{{% notice warning %}}
+**Important**
+
+We strongly recommend to customize your database prefix instead of using the default one.
+
+{{% /notice %}}
+
 All table names are in lowercase, and words are separated with an underscore character (“_”):
 
 * ps_employee

--- a/src/content/1.7/development/database/_index.md
+++ b/src/content/1.7/development/database/_index.md
@@ -12,7 +12,8 @@ By default, PrestaShop’s database tables start with the `ps_` prefix. This can
 {{% notice warning %}}
 **Important**
 
-We strongly recommend to customize your database prefix instead of using the default one.
+For security reasons We strongly recommend to customize your database prefix instead of using the default one.
+Changing it will help protect your shop against any attacks (some SQL injection for example) targeting the default table names
 
 {{% /notice %}}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add `notice warning` about default `database prefix`. Changing it will help protect your shop against any attacks (some SQL injection for example) targeting the default table names
| Fixed ticket? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
