### PR TITLE
Change order view page hooks image

### DIFF
--- a/src/content/1.7/modules/sample-modules/order-pages-new-hooks/_index.md
+++ b/src/content/1.7/modules/sample-modules/order-pages-new-hooks/_index.md
@@ -55,7 +55,7 @@ And on the listing page:
  
 These hooks are visualized in the picture below:
 
- {{< figure src="../img/view-order-hooks-demo/ps-view-order-page-hooks.jpg" title="Order view page hooks locations" >}}
+ {{< figure src="../img/order-view-page-hooks.jpg" title="Order view page hooks locations" >}}
  
  {{< figure src="../img/view-order-hooks-demo/ps-listing-order-page-hook.png" title="Order listing page hooks locations" >}}
 

--- a/src/content/1.7/modules/sample-modules/order-pages-new-hooks/_index.md
+++ b/src/content/1.7/modules/sample-modules/order-pages-new-hooks/_index.md
@@ -55,7 +55,7 @@ And on the listing page:
  
 These hooks are visualized in the picture below:
 
- {{< figure src="../img/order-view-page-hooks.jpg" title="Order view page hooks locations" >}}
+ {{< figure src="../../core-updates/img/order-view-page-hooks.jpg" title="Order view page hooks locations" >}}
  
  {{< figure src="../img/view-order-hooks-demo/ps-listing-order-page-hook.png" title="Order listing page hooks locations" >}}
 


### PR DESCRIPTION
Change from this:
https://devdocs.prestashop.com/1.7/modules/sample-modules/img/view-order-hooks-demo/ps-view-order-page-hooks.jpg

to this:
https://devdocs.prestashop.com/1.7/modules/core-updates/img/order-view-page-hooks.jpg

| Sponsor company | impSolutions