### PR TITLE
Correctly highlight smarty+html syntax

### DIFF
--- a/src/content/1.7/development/components/smarty-extensions/_index.md
+++ b/src/content/1.7/development/components/smarty-extensions/_index.md
@@ -77,7 +77,7 @@ Here are some examples:
 
 If you need to escape quotes in the _translated_ text, do it like this:
 
-```html+smarty
+```smarty
 <script type="text/javascript">
   var thisIsAString = '{l|escape:"javascript" s="Don't do this at home" d="Modules.Mymodule"}';
 </script>
@@ -89,7 +89,7 @@ This function renders the specified template. Some variables coming from the con
 
 So far, it is only used for forms (customer information and checkout).
 
-```html+smarty
+```smarty
   {render file="customer/_partials/login-form.tpl" ui=$login_form}
 ```
 
@@ -110,7 +110,7 @@ This will take care of SSL, domain name, virtual and physical base URI, paramete
 
 Here is a few examples:
 
-```html+smarty
+```smarty
   {url entity=address id=$id_address}
   {url entity=address params=['id_address' => $id_address]}
   {url entity=address id=$id_address params=['delete' => 1]}
@@ -142,7 +142,7 @@ This function lets you display content from the module in your template.
 
 Here is an example from classic theme, it displays the shop contact details wherever you want.
 
-```html+smarty
+```smarty
   <div id="sidebar">
     {widget name="ps_contactinfo"}
   </div>
@@ -151,7 +151,7 @@ Here is an example from classic theme, it displays the shop contact details wher
 Since the module may have a different behavior depending on which hook they are hooked on, you can pass the
 hook name.
 
-```html+smarty
+```smarty
   <div id="footer">
     {widget name="ps_contactinfo" hook="displayFooter"}
   </div>
@@ -165,7 +165,7 @@ the template file.
 Taking the Link list module as an example.
 Instead of redefining `ps_linklist/views/templates/hook/linkblock.tpl` ([source](https://github.com/PrestaShop/ps_linklist/blob/v2.1.6/views/templates/hook/linkblock.tpl)), you can override it this way:
 
-```html+smarty
+```smarty
   {widget_block name="ps_linklist"}
     {foreach $linkBlocks as $linkBlock}
       <ul>
@@ -228,7 +228,7 @@ Note that each class name is passed through the `classname` modifier.
 
 This way, this Smarty code:
 
-```html+smarty
+```smarty
   <body class="{$page.body_classes|classnames}">
 ```
 

--- a/src/content/1.7/themes/reference/template-inheritance/_index.md
+++ b/src/content/1.7/themes/reference/template-inheritance/_index.md
@@ -40,7 +40,7 @@ In a PrestaShop theme, many pages are very similar, for example template listing
 new products, search results, and so on. All of them display a list of products so in PS 1.7 they all
 extend `catalog/listing/product-list.tpl` (which extends the main layout).
 
-```html+smarty
+```smarty
   {extends file=$layout}
 
   {block name='content'}
@@ -61,7 +61,7 @@ extend `catalog/listing/product-list.tpl` (which extends the main layout).
 The template will show a title and a list of products underneath. For category page, we want a nice
 description with an cover image. So we can simply override the *product_list_header*
 
-```html+smarty
+```smarty
   {extends file='catalog/listing/product-list.tpl'}
 
   {block name='product_list_header'}

--- a/src/content/1.7/themes/reference/templates/head.md
+++ b/src/content/1.7/themes/reference/templates/head.md
@@ -29,7 +29,7 @@ loading for javascript or automatic inline for CSS.
   The `_partials/javascript.tpl` has to be included at the bottom of your page as well.
 {{% /notice %}}
 
-```html+smarty
+```smarty
   {block name='stylesheets'}
     {include file="_partials/stylesheets.tpl" stylesheets=$stylesheets}
   {/block}
@@ -48,7 +48,7 @@ A lot of meta and SEO information belong here, there is a special block for it
 so template which extend this layout can easily redefine the page title or
 description.
 
-```html+smarty
+```smarty
   {block name='head_seo'}
 
     <title>{block name='head_seo_title'}{$page.meta.title}{/block}</title>

--- a/src/content/1.7/themes/reference/templates/notifications.md
+++ b/src/content/1.7/themes/reference/templates/notifications.md
@@ -37,7 +37,7 @@ An array of notification is passed to the templates, containing at least one of 
 
 In the "Classic" Theme, [notifications are implemented as a partial template file](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.0/themes/classic/templates/_partials/notifications.tpl):
 
-```html+smarty
+```smarty
 <aside id="notifications">
 
   {if $notifications.error}

--- a/src/content/1.7/themes/reference/templates/templates-layouts.md
+++ b/src/content/1.7/themes/reference/templates/templates-layouts.md
@@ -118,7 +118,7 @@ Typical layout files look like the following snippet. This one is a full one
   Remember to define as many blocks as possible.
 {{% /notice %}}
 
-```html+smarty
+```smarty
     <!doctype html>
     <html lang="{$language.iso_code}">
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `html+smarty` doesn't work where `smarty` alone does 🤔 
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
