### PR TITLE
Add note about use of underscores in module's main class name

### DIFF
--- a/src/content/1.7/modules/creation/_index.md
+++ b/src/content/1.7/modules/creation/_index.md
@@ -51,7 +51,7 @@ describe its structure. We will name it "My module".
 
 First, create the module's folder, in the `/modules` folder. It should
 have the same name as the module, with no space, only alphanumerical
-characters, the hyphen and the underscore, all in lowercase:
+characters, the hyphen and the underscore (note: underscores will not pass the [module validation](https://validator.prestashop.com/)), all in lowercase:
 `/mymodule`.
 
 This folder must contain the main file, a PHP file of the same name as


### PR DESCRIPTION
Following the [recommendation](https://prestashop.slack.com/archives/C010UHP5PAR/p1623169179089700?thread_ts=1623139312.087000&cid=C010UHP5PAR) of @eternoendless.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Underscores are not accepted for a module's main class. See discussion here: https://prestashop.slack.com/archives/C010UHP5PAR/p1623139312087000.
| Fixed ticket? | Fixes #1032