### PR TITLE
Remove of actionFrontControllerAfterInit hook

### DIFF
--- a/src/content/1.7/modules/core-updates/1.7.7.md
+++ b/src/content/1.7/modules/core-updates/1.7.7.md
@@ -115,7 +115,7 @@ However in certain situations, these hooks were the only extension points availa
 - actionControllerInitAfter
 - actionControllerInitBefore
 
-The hook actionFrontControllerAfterInit has been removed.
+The hook actionFrontControllerAfterInit has been removed (an alias is still there to avoid BC break).
 
 ## Database table charset updated
 

--- a/src/content/1.7/modules/core-updates/1.7.7.md
+++ b/src/content/1.7/modules/core-updates/1.7.7.md
@@ -115,6 +115,8 @@ However in certain situations, these hooks were the only extension points availa
 - actionControllerInitAfter
 - actionControllerInitBefore
 
+The hook actionFrontControllerAfterInit has been removed.
+
 ## Database table charset updated
 
 All database tables have been switched to the utf8mb4 charset in order to provide support for emojis.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | remove of actionFrontControllerAfterInit hook in 1.7.7, see it there https://github.com/PrestaShop/PrestaShop/pull/21435/files#r655368715
| Fixed ticket? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
