### PR TITLE
Introduce Algolia DocSearch

### DIFF
--- a/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
@@ -47,22 +47,36 @@ a:hover {
 }
 #sidebar {
   background-color: $menuSectionsBgColor;
+  z-index: 100;
+
   #header-wrapper {
     background: $menuHeaderBgColor;
     color: $menuSearchBoxColor;
     border-color: $menuHeaderBgColor;
     background: linear-gradient(#411452, #840e5f);
   }
-  .searchbox {
+  .searchbox-extended {
     border-color: $menuSearchBoxColor;
     background: $menuSearchBgColor;
+
+    .algolia-docsearch-suggestion--category-header-lvl0 {
+      .algolia-docsearch-suggestion--highlight {
+        box-shadow: inset 0 -2px 0 0 rgba($primaryColor, .8);
+      }
+    }
+
+    .algolia-docsearch-suggestion--highlight {
+      color: $primaryColor; 
+    }
   }
   ul.topics > li.parent,
   ul.topics > li.active {
     background: $menuSectionsActiveBgColor;
   }
-  .searchbox * {
-    color: $menuSearchBoxIconsColor;
+  .searchbox-extended {
+    input, i {
+      color: $menuSearchBoxIconsColor;
+    }
   }
   a {
     color: $menuSectionsLinkColor;

--- a/src/themes/hugo-theme-learn/assets/sass/_theme.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_theme.scss
@@ -126,7 +126,7 @@ select[multiple='multiple'] {
   }
 }
 
-.searchbox {
+.searchbox-extended {
   margin-top: 1rem;
   position: relative;
   border: 1px solid #915eae;
@@ -140,11 +140,10 @@ select[multiple='multiple'] {
     top: 3px;
   }
 
-  span {
+  > span {
     color: rgba(255, 255, 255, 0.6);
     position: absolute;
     right: 10px;
-    top: 3px;
     cursor: pointer;
 
     &:hover {

--- a/src/themes/hugo-theme-learn/layouts/partials/custom-footer.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/custom-footer.html
@@ -10,6 +10,6 @@
 apiKey: 'e5a3a32dad46a5aaaa771b2b37d7084a',
 indexName: 'prestashop',
 inputSelector: '#search-by',
-debug: true // for debug only, let's set it to false when we're done with styling
+debug: false
 });
 </script>

--- a/src/themes/hugo-theme-learn/layouts/partials/custom-footer.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/custom-footer.html
@@ -4,3 +4,12 @@
 </script>
 -->
 {{ template "_internal/google_analytics.html" . }}
+
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+apiKey: 'e5a3a32dad46a5aaaa771b2b37d7084a',
+indexName: 'prestashop',
+inputSelector: '#search-by',
+debug: true // for debug only, let's set it to false when we're done with styling
+});
+</script>

--- a/src/themes/hugo-theme-learn/layouts/partials/custom-footer.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/custom-footer.html
@@ -1,8 +1,3 @@
-<!-- Partial intended to be overwritten with tags loaded at the end of the page loading (usually for Javascript)
-<script>
-    console.log("running some javascript");
-</script>
--->
 {{ template "_internal/google_analytics.html" . }}
 
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>

--- a/src/themes/hugo-theme-learn/layouts/partials/custom-header.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/custom-header.html
@@ -3,3 +3,4 @@
     /* Custom css */
 </style>
 -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

--- a/src/themes/hugo-theme-learn/layouts/partials/custom-header.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/custom-header.html
@@ -1,6 +1,1 @@
-<!-- Partial intended to be overwritten to add custom headers, like CSS or any other info
-<style type="text/css">
-    /* Custom css */
-</style>
--->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

--- a/src/themes/hugo-theme-learn/layouts/partials/search.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/search.html
@@ -1,4 +1,4 @@
-<div>
+<div class="searchbox-extended">
     <label for="search-by"><i class="fa fa-search"></i></label>
     <input id="search-by" type="search" placeholder="{{T "Search-placeholder"}}">
 </div>

--- a/src/themes/hugo-theme-learn/layouts/partials/search.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/search.html
@@ -1,16 +1,5 @@
-<div class="searchbox">
+<div>
     <label for="search-by"><i class="fa fa-search"></i></label>
-    <input data-search-input id="search-by" type="search" placeholder="{{T "Search-placeholder"}}">
-    <span data-search-clear=""><i class="fa fa-close"></i></span>
+    <input id="search-by" type="search" placeholder="{{T "Search-placeholder"}}">
 </div>
-{{ $assetBusting := not .Site.Params.disableAssetsBusting }}
-<script type="text/javascript" src="{{"js/lunr.min.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
-<script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
-<script type="text/javascript">
-    {{ if .Site.IsMultiLingual }}
-        var baseurl = "{{.Site.LanguagePrefix | relURL }}";
-    {{ else }}
-        var baseurl = '{{ "" | relURL }}';
-    {{ end }}
-</script>
-<script type="text/javascript" src="{{"js/search.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
+


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Introduce Algolia DocSearch
| Fixed ticket? | Fixes https://github.com/PrestaShop/docs/issues/1001

I applied for [DocSearch](https://docsearch.algolia.com/) and was provided by the amazing Algolia team with a ready-to-use integration of Algolia for devdocs.prestashop.com

Integration requirements:
```
<!-- at the end of the HEAD -->
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

<!-- at the end of the BODY -->
<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
<script type="text/javascript"> docsearch({
apiKey: 'e5a3a32dad46a5aaaa771b2b37d7084a',
indexName: 'prestashop',
inputSelector: '### REPLACE ME ####',
debug: false // Set debug to true if you want to inspect the dropdown
});
</script>
```

To improve the styling:
See https://docsearch.algolia.com/docs/styling/

Our configuration:
See https://github.com/algolia/docsearch-configs/blob/master/configs/prestashop.json). We can submit changes to improve the indexing.

![image](https://user-images.githubusercontent.com/14963751/123242108-fea6b380-d4e1-11eb-8663-37ac275722f7.png)

