### PR TITLE
FIX typo on deprecated properties

### DIFF
--- a/src/content/1.7/modules/core-updates/1.7.8.md
+++ b/src/content/1.7/modules/core-updates/1.7.8.md
@@ -140,7 +140,7 @@ The following dependencies have been updated in order to provide support for PHP
 | Class name                            | Alternative                     |
 |---------------------------------------|---------------------------------|
 | `Combination::$location`              | `StockAvailable::$location`     |
-| `Combination::$quantity`              | `StockAvailable::$location`     |
+| `Combination::$quantity`              | `StockAvailable::$quantity`     |
 | `Product::$quantity`                  | `StockAvailable::$quantity`     |
 | `Product::$location`                  | `StockAvailable::$location`     |
 | `Product::$out_of_stock`              | `StockAvailable::$out_of_stock` |


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |  `Combination::$quantity` has an alternative with `StockAvailable::$quantity` (not `StockAvailable::$location`)
| Fixed ticket? | -