### PR TITLE
Precise nodejs version, how to switch and node-gyp dependency on Windows

### DIFF
--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -13,11 +13,11 @@ PrestaShop uses [Webpack](https://webpack.js.org/) to compile assets, which requ
 
 You will need a different NodeJS version depending on the PrestaShop version you're working with:
 
-| PrestaShop Versions | NodeJS Versions |
-|---------------------|-----------------|
-| 1.7.0~1.7.6          | 8.x   |
-| 1.7.7               | 10.x            |
-| 1.7.8               | 12.x and 14.x   |
+| PrestaShop Versions | NodeJS Versions | NPM Versions |
+|---------------------|-----------------|--------------|
+| 1.7.0~1.7.6         | 8.x             | 5.x          |
+| 1.7.7               | 10.x            | 6.x          |
+| 1.7.8               | 12.x and 14.x   | 6.x          |
 
 
 If you are struggling to compile assets, you might be using the wrong NodeJs version. We strongly recommend you to use a version manager such as ['n'](https://www.npmjs.com/package/n) or [nvm](https://github.com/nvm-sh/nvm) so you can easily switch between NodeJS versions.

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -13,7 +13,7 @@ Here is a list of compatibility:
 
 | PrestaShop Versions | NodeJS Versions |
 |---------------------|-----------------|
-| > 1.7.7             | 8.x and older   |
+| under 1.7.7         | 8.x and older   |
 | 1.7.7               | 10.x            |
 | 1.7.8               | 12.x and 14.x   |
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -20,7 +20,7 @@ Here is a list of compatibility:
 | 1.7.8               | 12.x and 14.x   |
 
 
-If you can't manage to compile assets, you may be using an older version of PrestaShop. We strongly recommend you ton install a package such as ['n'](https://www.npmjs.com/package/n?activeTab=versions) or [nvm](https://github.com/nvm-sh/nvm) to try with an older version of NodeJS.
+If you are struggling to compile assets, you might be using the wrong NodeJs version. We strongly recommend you to use a version manager such as ['n'](https://www.npmjs.com/package/n) or [nvm](https://github.com/nvm-sh/nvm) so you can easily switch between NodeJS versions.
 
 On Windows, you'll probably need to install `windows-build-tools` using `npm i --global windows-build-tools` in order to make [node-gyp](https://github.com/nodejs/node-gyp#on-windows) working.
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -9,7 +9,16 @@ Some components in PrestaShop, like Javascript or SCSS files, need to be compile
 
 ## Requirements
 
-We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop should be compatible with NodeJS 10.x, 12.x and 14.x ([get it here](https://nodejs.org/)), NPM will take care of it all.
+Here is a list of compatibility:
+
+| PrestaShop Versions | NodeJS Versions |
+|---------------------|-----------------|
+| > 1.7.7             | 8.x and older   |
+| 1.7.7               | 10.x            |
+| 1.7.8               | 12.x            |
+| 8.x                 | 14.x            |
+
+We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop is using NodeJS ([get it here](https://nodejs.org/)), NPM will take care of it all.
 
 If you can't manage to compile assets, you may be using an older version of PrestaShop. We strongly recommend you ton install a package such as ['n'](https://www.npmjs.com/package/n?activeTab=versions) or [nvm](https://github.com/nvm-sh/nvm) to try with an older version of NodeJS.
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -9,7 +9,9 @@ Some components in PrestaShop, like Javascript or SCSS files, need to be compile
 
 ## Requirements
 
-We use [Webpack](https://webpack.js.org/) to compile assets. You only need NodeJS from 8.x to 12.x ([get it here](https://nodejs.org/)), NPM will take care of it all.
+PrestaShop development is following tools version, such as webpack which could be incompatible with some NodeJS versions. This means that at the time we developed one version of PrestaShop, we may used an older version of NodeJS. We strongly recommend you ton install a package such as ['n'](https://www.npmjs.com/package/n?activeTab=versions) or [nvm](https://github.com/nvm-sh/nvm) to switch between versions.
+
+We use [Webpack](https://webpack.js.org/) to compile assets. Currently, you only need NodeJS 12.x ([get it here](https://nodejs.org/)), NPM will take care of it all.
 
 ## Assets that need to be compiled
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -9,9 +9,9 @@ Some components in PrestaShop, like Javascript or SCSS files, need to be compile
 
 ## Requirements
 
-PrestaShop development is following tools version, such as webpack which could be incompatible with some NodeJS versions. This means that at the time we developed one version of PrestaShop, we may used an older version of NodeJS. We strongly recommend you ton install a package such as ['n'](https://www.npmjs.com/package/n?activeTab=versions) or [nvm](https://github.com/nvm-sh/nvm) to switch between versions.
+We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop should be compatible with NodeJS 10.x, 12.x and 14.x ([get it here](https://nodejs.org/)), NPM will take care of it all.
 
-We use [Webpack](https://webpack.js.org/) to compile assets. Currently, you only need NodeJS 12.x ([get it here](https://nodejs.org/)), NPM will take care of it all.
+If you can't manage to compile assets, you may be using an older version of PrestaShop. We strongly recommend you ton install a package such as ['n'](https://www.npmjs.com/package/n?activeTab=versions) or [nvm](https://github.com/nvm-sh/nvm) to try with an older version of NodeJS.
 
 On Windows, you'll probably need to install `windows-build-tools` using `npm i --global windows-build-tools` in order to make [node-gyp](https://github.com/nodejs/node-gyp#on-windows) working.
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -13,6 +13,8 @@ PrestaShop development is following tools version, such as webpack which could b
 
 We use [Webpack](https://webpack.js.org/) to compile assets. Currently, you only need NodeJS 12.x ([get it here](https://nodejs.org/)), NPM will take care of it all.
 
+On Windows, you'll probably need to install `windows-build-tools` using `npm i --global windows-build-tools` in order to make [node-gyp](https://github.com/nodejs/node-gyp#on-windows) working.
+
 ## Assets that need to be compiled
 
 - Back Office

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -22,7 +22,7 @@ Here is a list of compatibility:
 
 If you are struggling to compile assets, you might be using the wrong NodeJs version. We strongly recommend you to use a version manager such as ['n'](https://www.npmjs.com/package/n) or [nvm](https://github.com/nvm-sh/nvm) so you can easily switch between NodeJS versions.
 
-On Windows, you'll probably need to install `windows-build-tools` using `npm i --global windows-build-tools` in order to make [node-gyp](https://github.com/nodejs/node-gyp#on-windows) working.
+On Windows, you'll probably need to install `windows-build-tools` using `npm i --global windows-build-tools` in order to [make node-gyp work](https://github.com/nodejs/node-gyp#on-windows).
 
 ## Assets that need to be compiled
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -15,7 +15,7 @@ Here is a list of compatibility:
 
 | PrestaShop Versions | NodeJS Versions |
 |---------------------|-----------------|
-| under 1.7.7         | 8.x and older   |
+| 1.7.0~1.7.6          | 8.x   |
 | 1.7.7               | 10.x            |
 | 1.7.8               | 12.x and 14.x   |
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -11,7 +11,7 @@ Some components in PrestaShop, like Javascript or SCSS files, need to be compile
 
 PrestaShop uses [Webpack](https://webpack.js.org/) to compile assets, which requires NodeJS ([get it here](https://nodejs.org/)).
 
-Here is a list of compatibility:
+You will need a different NodeJS version depending on the PrestaShop version you're working with:
 
 | PrestaShop Versions | NodeJS Versions |
 |---------------------|-----------------|

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -9,6 +9,8 @@ Some components in PrestaShop, like Javascript or SCSS files, need to be compile
 
 ## Requirements
 
+We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop is using NodeJS ([get it here](https://nodejs.org/)), NPM will take care of it all.
+
 Here is a list of compatibility:
 
 | PrestaShop Versions | NodeJS Versions |
@@ -17,7 +19,6 @@ Here is a list of compatibility:
 | 1.7.7               | 10.x            |
 | 1.7.8               | 12.x and 14.x   |
 
-We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop is using NodeJS ([get it here](https://nodejs.org/)), NPM will take care of it all.
 
 If you can't manage to compile assets, you may be using an older version of PrestaShop. We strongly recommend you ton install a package such as ['n'](https://www.npmjs.com/package/n?activeTab=versions) or [nvm](https://github.com/nvm-sh/nvm) to try with an older version of NodeJS.
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -9,7 +9,7 @@ Some components in PrestaShop, like Javascript or SCSS files, need to be compile
 
 ## Requirements
 
-We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop is using NodeJS ([get it here](https://nodejs.org/)), NPM will take care of it all.
+PrestaShop uses [Webpack](https://webpack.js.org/) to compile assets, which requires NodeJS ([get it here](https://nodejs.org/)).
 
 Here is a list of compatibility:
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -15,8 +15,7 @@ Here is a list of compatibility:
 |---------------------|-----------------|
 | > 1.7.7             | 8.x and older   |
 | 1.7.7               | 10.x            |
-| 1.7.8               | 12.x            |
-| 8.x                 | 14.x            |
+| 1.7.8               | 12.x and 14.x   |
 
 We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop is using NodeJS ([get it here](https://nodejs.org/)), NPM will take care of it all.
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Nodejs needed some precisions for windows, and to explain why some version would need an older nodejs version
| Fixed ticket? | Fixes https://github.com/PrestaShop/docs/issues/663

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
