### PR TITLE
Explains how to import ts files instead of js files

### DIFF
--- a/src/content/1.7/development/coding-standards/_index.md
+++ b/src/content/1.7/development/coding-standards/_index.md
@@ -118,6 +118,19 @@ If you need to deprecate services, you can use the `deprecated` key for the serv
 
 Javascript files MUST follow the [Airbnb Javascript style guide](https://github.com/airbnb/javascript).
 
+Starting on {{< minver v="1.7.8" >}}, you can run the linter like this:
+
+```bash
+npm run lint-fix
+```
+
+## TypeScript
+Starting on {{< minver v="1.7.9" >}}, most of `admin-dev/themes/new-theme/js` files have been migrated to TypeScript. This provide a better maintainability by using types on most of our classes and functions. 
+
+You are able to get global types in the `admin-dev/themes/new-theme/js/types` folder and some types library are imported from npm using the `@types` namespace and automatically imported by TypeScript.
+
+The `tsconfig.json` and `webpack` configuration files are adding a `@PSTypes` relative path to the `admin-dev/themes/new-theme/js/types` folder, because `@types` is a reserved folder.
+
 ## HTML, CSS (Sass), Twig & Smarty code conventions
 
 HTML, CSS (Sass), Twig and Smarty files MUST follow the [Mark Otto's coding standards](https://codeguide.co/).

--- a/src/content/1.7/development/coding-standards/_index.md
+++ b/src/content/1.7/development/coding-standards/_index.md
@@ -118,7 +118,7 @@ If you need to deprecate services, you can use the `deprecated` key for the serv
 
 Javascript files MUST follow the [Airbnb Javascript style guide](https://github.com/airbnb/javascript).
 
-Starting on {{< minver v="1.7.8" >}}, you can run the linter like this:
+Starting on {{< minver v="1.7.8" >}}, you can run the linter to help you comply with these coding standards:
 
 ```bash
 npm run lint-fix

--- a/src/content/1.7/development/coding-standards/_index.md
+++ b/src/content/1.7/development/coding-standards/_index.md
@@ -123,14 +123,6 @@ Starting on {{< minver v="1.7.8" >}}, you can run the linter like this:
 ```bash
 npm run lint-fix
 ```
-
-## TypeScript
-Starting on {{< minver v="1.7.9" >}}, most of `admin-dev/themes/new-theme/js` files have been migrated to TypeScript. This provide a better maintainability by using types on most of our classes and functions. 
-
-You are able to get global types in the `admin-dev/themes/new-theme/js/types` folder and some types library are imported from npm using the `@types` namespace and automatically imported by TypeScript.
-
-The `tsconfig.json` and `webpack` configuration files are adding a `@PSTypes` relative path to the `admin-dev/themes/new-theme/js/types` folder, because `@types` is a reserved folder.
-
 ## HTML, CSS (Sass), Twig & Smarty code conventions
 
 HTML, CSS (Sass), Twig and Smarty files MUST follow the [Mark Otto's coding standards](https://codeguide.co/).

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -33,7 +33,7 @@ Example of a TypeScript loader:
 },
 ```
 
-Example of a TypeScript config file:
+Example of a TypeScript configuration file:
 ```javascript
 {
   "compilerOptions": {

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -20,7 +20,7 @@ import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/compone
 import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/components/auto-complete-search'
 ```
 
-If you need to carry out the above import, it is likely you use a bundler such as Webpack or Parcel. If the file you are trying to import is a TypeScript file, you need to add the TypeScript loader to your project and a `tsconfig` file.
+If you need to carry out the above import, it is likely you will be using a bundler such as Webpack or Parcel. If the file you are trying to import is a TypeScript file, you need to add the TypeScript loader to your project and a `tsconfig` file.
 
 Example of a TypeScript loader:
 ```javascript

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -11,7 +11,7 @@ aliases:
 
 Most of the time, you want to use the [global JavaScript components][global JavaScript components] object but in some cases, you may want to import a component using a static path such as `admin-dev/themes/new-theme/js/components/auto-complete-search.ts`.
 
-**We do not recommend to do this**, but in case you absolutly need it be careful to import the file without any extensions:
+**We do not recommend to do this**, but in case you absolutely need it, be careful to import the file without any extensions:
 
 ```javascript
 // Incorrect

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -22,7 +22,7 @@ import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/compone
 import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/components/auto-complete-search'
 ```
 
-As you're importing this, we consider that you're using a bundler such as Webpack or Parcel. If the file you're trying to import is a TypeScript file, you'll need to add the `TypeScript loader` to your project and a `tsconfig` file.
+If you need to carry out the above import, it is likely you use a bundler such as Webpack or Parcel. If the file you are trying to import is a TypeScript file, you need to add the TypeScript loader to your project and a `tsconfig` file.
 
 Example of a TypeScript loader:
 ```javascript

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -7,9 +7,9 @@ weight: 4
 # How to import Core JavaScript files
 {{< minver v="1.7.8" title="true">}}
 
-Most of the time, you want to use the [global JavaScript components][global JavaScript components] object but in some cases, you may want to import a component using a static path such as `admin-dev/themes/new-theme/js/components/auto-complete-search.ts`.
+Most of the time, you will use the [global JavaScript components][global JavaScript components] object. However, in some cases, you might want to import a Core component using a static path, such as `admin-dev/themes/new-theme/js/components/auto-complete-search.ts`.
 
-**We do not recommend to do this**, but in case you absolutely need it, be careful to import the file without any extensions:
+**We don't recommend doing this.** If you absolutely need it, make sure to remove the file extension from the import path:
 
 ```javascript
 // Incorrect

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -1,6 +1,6 @@
 ---
 title: How to import Core JavaScript files 
-menuTitle: Import core js files
+menuTitle: Import Core JavaScript files
 weight: 4
 aliases:
 - 1.7/modules/templating/

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -22,7 +22,7 @@ import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/compone
 import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/components/auto-complete-search'
 ```
 
-As you're importing this, we consider that you're using a bundler such as Webpack or Parcel. If the file you're trying to import is a TypeScript file, you'll need to add the `TypeScript loader` to you're project and a `tsconfig` file.
+As you're importing this, we consider that you're using a bundler such as Webpack or Parcel. If the file you're trying to import is a TypeScript file, you'll need to add the `TypeScript loader` to your project and a `tsconfig` file.
 
 Example of a TypeScript loader:
 ```javascript

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -1,0 +1,70 @@
+---
+title: How to import core js files 
+menuTitle: Import core js files
+weight: 4
+aliases:
+- 1.7/modules/templating/
+---
+
+# How to import core js files
+{{< minver v="1.7.8" title="true">}}
+
+Most of times, you want to use the [global JavaScript components][global JavaScript components] object but in some cases, you may wants to import a component using a static path such as `admin-dev/themes/new-theme/js/components/auto-complete-search.ts`.
+
+**We do not recommend to do this**, but in case you absolutly need it be careful to import the file without any extensions:
+
+```javascript
+// Incorrect
+import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/components/auto-complete-search.js'
+import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/components/auto-complete-search.ts'
+
+// Correct
+import AutoCompletSearch from '../../../../admin-dev/themes/new-theme/js/components/auto-complete-search'
+```
+
+As you're importing this, we consider that you're using a bundler such as Webpack or Parcel. If the file you're trying to import is a TypeScript file, you'll need to add the `TypeScript loader` to you're project and a `tsconfig` file.
+
+Example of a TypeScript loader:
+```javascript
+{
+  test: /\.ts?$/,
+  use: 'ts-loader',
+  exclude: /node_modules/,
+},
+```
+
+Example of a TypeScript config file:
+```javascript
+{
+  "compilerOptions": {
+    "outDir": "./public/",
+    "noImplicitAny": true,
+    "module": "es6",
+    "target": "es5",
+    "strict": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true,
+    "baseUrl": "./",
+    "paths": {
+      "@app/*": ["js/app/*"],
+      "@js/*": ["js/*"],
+      "@pages/*": ["js/pages/*"],
+      "@components/*": ["js/components/*"],
+      "@scss/*": ["scss/*"],
+      "@node_modules/*": ["node_modules/*"],
+      "@vue/*": ["js/vue/*"],
+      "@PSTypes/*": ["js/types/*"]
+    },
+    "typeRoots": ["js/types", "node_modules/@types"]
+  },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  }
+}
+```
+
+
+[global JavaScript components]: {{< ref "/1.7/development/components/global-components" >}}

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -1,12 +1,12 @@
 ---
-title: How to import core js files 
+title: How to import Core JavaScript files 
 menuTitle: Import core js files
 weight: 4
 aliases:
 - 1.7/modules/templating/
 ---
 
-# How to import core js files
+# How to import Core JavaScript files
 {{< minver v="1.7.8" title="true">}}
 
 Most of the time, you want to use the [global JavaScript components][global JavaScript components] object but in some cases, you may want to import a component using a static path such as `admin-dev/themes/new-theme/js/components/auto-complete-search.ts`.

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -2,8 +2,6 @@
 title: How to import Core JavaScript files 
 menuTitle: Import Core JavaScript files
 weight: 4
-aliases:
-- 1.7/modules/templating/
 ---
 
 # How to import Core JavaScript files

--- a/src/content/1.7/modules/concepts/templating/import-js.md
+++ b/src/content/1.7/modules/concepts/templating/import-js.md
@@ -9,7 +9,7 @@ aliases:
 # How to import core js files
 {{< minver v="1.7.8" title="true">}}
 
-Most of times, you want to use the [global JavaScript components][global JavaScript components] object but in some cases, you may wants to import a component using a static path such as `admin-dev/themes/new-theme/js/components/auto-complete-search.ts`.
+Most of the time, you want to use the [global JavaScript components][global JavaScript components] object but in some cases, you may want to import a component using a static path such as `admin-dev/themes/new-theme/js/components/auto-complete-search.ts`.
 
 **We do not recommend to do this**, but in case you absolutly need it be careful to import the file without any extensions:
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since we migrated to TypeScript, modules devs importing hardlinks may have some problems without the ts-loader, here is a doc to explain it. It also add some explanations about the typescript implementation.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
