### PR TITLE
Improve introduction, move cache section to core/architecture

### DIFF
--- a/src/content/1.7/development/architecture/cache.md
+++ b/src/content/1.7/development/architecture/cache.md
@@ -1,0 +1,16 @@
+---
+title: Cache
+---
+
+# Cache
+
+## Classes in the root namespace and overrides
+
+The `/var/cache/<ENV>/class_index.php` file contains the link between the class and the declaration file. If there is a caching issue, this file can safely be deleted.
+
+## Smarty
+
+When the store's front-end doesn't quite reflect your changes and emptying the browser's cache is not effective, try emptying the following folders:
+
+- `/var/cache/<ENV>/smarty/cache`
+- `/var/cache/<ENV>/smarty/compile`

--- a/src/content/1.7/modules/introduction.md
+++ b/src/content/1.7/modules/introduction.md
@@ -5,8 +5,7 @@ weight: 1
 
 # Introduction
 
-Technical principles behind a module
-------------------------------------
+## Technical principles behind a module
 
 A PrestaShop module consists of a main PHP file with as many other PHP
 files as needed, as well as the necessary template (`.tpl`) files and
@@ -21,80 +20,37 @@ the cart or the product sheet, when displaying the current stock, etc.).
 Specifically, a hook is a shortcut to the various methods available from
 the `Module` object, as assigned to that hook.
 
-For security reasons, during validation, we do not accept any call
-to another website/API in order to retrieve code that will later be
-executed on server or client.
+{{% notice note %}}
+Injecting executable code via third party API or services is considered a security threat and is therefore forbidden for modules sold in the Addons Marketplace.
+{{% /notice %}}
 
-Modules' operating principles
------------------------------
+## Modules' operating principles
 
 Modules are the ideal way to let your talent and imagination as a
 developer express themselves, as the creative possibilities are many and
 you can do pretty much anything with PrestaShop's module API.
 
-Any module:
+Modules can:
 
--   can display a variety of content (blocks, text, etc.), perform many
-    tasks (batch update, import, export, etc.), interface with other
-    tools, and much much more.
--   facilitates [interactions between the shop and external services]({{< ref "1.7/modules/creation/external-services" >}}).
--   can be made as configurable as necessary; the more configurable it
-    is, the easier it will be to use, and thus will be able to address
-    the needs of a wider range of users.
--   can add functionalities to PrestaShop without having to edit its
-    core files, thus making it easier to perform an update of PrestaShop
-    without having the transpose all core changes. Indeed, you should
-    always strive to stay away from core files when building a module,
-    even though this may seem necessary in some situations.
+- Extend or modify existing PrestaShop features, like adding a field in a form, a block of text, or an independent component — without modifying PrestaShop's files. This allows merchants to update their shops without requiring to apply your changes again.
+- Add new fully independent features (e.g. a new screen).
+- Perform a task (like batch update, import, export...)
+- Facilitate [interactions between the shop and external services]({{< relref "creation/external-services" >}}).
+- Be made as configurable as necessary (the more configurable it is, the more likely it will be able to address the needs of a wider range of users).
+- ...and much, much more!
 
-Main differences between 1.6 and 1.7 modules
---------------------------------------------
+## Main differences between 1.6 and 1.7 modules
 
-PrestaShop 1.7 was built so that modules that were written for PS 1.6
-could work almost as-is -- save for minor changes and a cosmetic update,
-the template files being in need of adapting to the 1.7 default theme.
+PrestaShop 1.7 was built so that modules that were written for PS 1.6 can work almost as-is — save for minor changes and a cosmetic update, the template files being in need of adapting to the 1.7 default theme.
 
-The major module development changes in PrestaShop 1.7 are explained in
-details [in this Build
-article](https://build.prestashop.com/news/module-development-changes-in-17/),
-and are integrated into this updated documentation. If you already know
-how to create a module that works with PS 1.6, we strongly advise you to
-read that article from top to bottom in order to get up to speed with
-1.7 development.
+The major module development changes in PrestaShop 1.7 are explained in details [in this Build article](https://build.prestashop.com/news/module-development-changes-in-17/), and are integrated into this updated documentation. If you already know how to create a module that works with PS 1.6, we strongly advise you to read that article from top to bottom in order to get up to speed with 1.7 development.
 
 Some native modules have had their names changed in PrestaShop 1.7. [See the full list here]({{< ref "/1.7/development/native-modules/_index.md#module-name-changes-since-16" >}}).
 
-Modules folder
---------------
+## Modules folder
 
-PrestaShop's modules are found in the `/modules` folder, which is at the
-root of the PrestaShop main folder. This is true for both default
-modules (provided with PrestaShop) and 3rd-party modules that are
-subsequently installed.
+PrestaShop's modules are found in the `modules` folder, located at the root of the PrestaShop main folder. This is true for both native modules (provided with PrestaShop) and any 3rd-party modules that are subsequently installed.
 
-Modules can also be part of a theme if they are really specific to it.
-In that case, they would be in the theme's own `/modules` folder, and
-therefore under the following path: `/themes/[my-theme]/modules`
+Modules can also be part of a theme if they are really specific to it. In that case, they would be located within the theme's own `modules` folder: `/themes/[my-theme]/modules`
 
-Each module has its own sub-folder inside the `/modules` folder:
-`/bankwire`, `/birthdaypresent`, etc.
-
-About the cache
----------------
-
-The `/var/cache/ENV/class_index.php` file contains the link between the class
-and the declaration file. If there is a caching issue, this file can
-safely be deleted.
-
-The `/config/xml` folder contains the list of all the base modules:
-
-    default_country_modules_list.xml
-    must_have_modules_list.xml
-    tab_modules_list.xml
-
-When the store's front-end doesn't quite reflect your changes and
-emptying the browser's cache is not effective, you should try emptying
-the following folders:
-
-    /var/cache/ENV/smarty/cache
-    /var/cache/ENV/smarty/compile
+Each module has its own sub-folder inside the `modules` folder: `/bankwire`, `/birthdaypresent`, etc.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Improved the module's introduction article, moved cache part to core/architecture because it had little to do with modules, really.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
