### PR TITLE
Fix spacing in definition lists

### DIFF
--- a/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
@@ -66,7 +66,7 @@ a:hover {
     }
 
     .algolia-docsearch-suggestion--highlight {
-      color: $primaryColor; 
+      color: $primaryColor;
     }
   }
   ul.topics > li.parent,
@@ -110,15 +110,10 @@ a:hover {
 
 .function-definition {
   dt {
-    font-family: 'Consolas', 'Menlo', monospace;
+    font-family: $monospaceFont;
     background: #f0f0f0;
     display: inline-block;
     padding: 0 5px;
-  }
-
-  dd {
-    margin-top: 5px;
-    margin-bottom: 10px;
   }
 }
 

--- a/src/themes/hugo-theme-learn/assets/sass/_theme.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_theme.scss
@@ -1186,3 +1186,25 @@ ol ol {
     list-style-type: lower-roman;
   }
 }
+
+// definition lists
+
+dt {
+  font-weight: bold;
+
+  code {
+    font-weight: normal;
+    font-size: 90%;
+  }
+}
+
+dd {
+  margin-top: 5px;
+  margin-bottom: 10px;
+
+  // for some reason, the first paragraph in definitions is not wrapped by a <p>
+  // so there's a margin missing between the first paragraph and one following
+  > p:first-child {
+    margin-top: 1rem;
+  }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This change fixes a spacing issue in definition lists
| Fixed ticket? | N/A

Here's what it looks like after the fix:

<img width="675" alt="Screenshot 2021-07-02 at 17 04 35" src="https://user-images.githubusercontent.com/1009343/124323410-a9107d80-db57-11eb-807e-d8058683c2df.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
