### PR TITLE
Add a notice for how to use API key in header

### DIFF
--- a/src/content/1.7/webservice/getting-started.md
+++ b/src/content/1.7/webservice/getting-started.md
@@ -268,11 +268,19 @@ Add the one of the following headers to your HTTP request:
 - `Io-Format: JSON`
 - `Output-Format: JSON`
 
+{{% notice note %}}
+According to the step of [using an authorization header]({{< relref "tutorials/testing-access/#using-an-authorization-header-recommended" >}}), you must encode your API Key using `base64_encode` for direct use in header.
+
+| API Key                             | base64_encode string                           |
+|-------------------------------------|------------------------------------------------|
+| `UCCLLQ9N2ARSHWCXLT74KUKSSK34BFKX:` | `VUNDTExROU4yQVJTSFdDWExUNzRLVUtTU0szNEJGS1g6` |
+{{% /notice %}}
+
 Example:
 
 ```http
 GET /api/ HTTP/1.1
 Host: example.com
 Output-Format: JSON
-Authorization: Basic UCCLLQ9N2ARSHWCXLT74KUKSSK34BFKX
+Authorization: Basic VUNDTExROU4yQVJTSFdDWExUNzRLVUtTU0szNEJGS1g6
 ```

--- a/src/content/1.7/webservice/getting-started.md
+++ b/src/content/1.7/webservice/getting-started.md
@@ -268,14 +268,6 @@ Add the one of the following headers to your HTTP request:
 - `Io-Format: JSON`
 - `Output-Format: JSON`
 
-{{% notice note %}}
-According to the step of [using an authorization header]({{< relref "tutorials/testing-access/#using-an-authorization-header-recommended" >}}), you must encode your API Key using `base64_encode` for direct use in header.
-
-| API Key                             | base64_encode string                           |
-|-------------------------------------|------------------------------------------------|
-| `UCCLLQ9N2ARSHWCXLT74KUKSSK34BFKX:` | `VUNDTExROU4yQVJTSFdDWExUNzRLVUtTU0szNEJGS1g6` |
-{{% /notice %}}
-
 Example:
 
 ```http
@@ -284,3 +276,7 @@ Host: example.com
 Output-Format: JSON
 Authorization: Basic VUNDTExROU4yQVJTSFdDWExUNzRLVUtTU0szNEJGS1g6
 ```
+
+{{% notice note %}}
+Note that the API key has been encoded in Base64 for use in headers, as explained in [Using an authorization header]({{< relref "tutorials/testing-access/#using-an-authorization-header-recommended" >}}).
+{{% /notice %}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |To use the API key in header, we need to encode the API key with `base64_encode`.
| Fixed ticket? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
