### PR TITLE
Fix diverse style issues

### DIFF
--- a/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
@@ -34,7 +34,7 @@ a:hover {
   color: $menuVisitedColor;
 }
 
-#body a.highlight:after {
+#body a:after {
   display: block;
   content: '';
   height: 1px;

--- a/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
@@ -143,6 +143,11 @@ a[data-featherlight] {
     right: 3rem;
   }
 
+  &:after {
+    // remove underline effect
+    content: none !important;
+  }
+
   > img {
     max-height: 350px;
   }

--- a/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_prestashop.scss
@@ -143,7 +143,7 @@ a[data-featherlight] {
     right: 3rem;
   }
 
-  &:after {
+  &::after {
     // remove underline effect
     content: none !important;
   }

--- a/src/themes/hugo-theme-learn/assets/sass/_theme.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_theme.scss
@@ -27,11 +27,6 @@ a {
   }
 }
 
-pre {
-  position: relative;
-  color: #ffffff;
-}
-
 .bg {
   background: #fff;
   border: 1px solid #eaeaea;
@@ -559,6 +554,8 @@ pre {
 div.highlight {
   margin: $paragraphSpacing * 1.5 0;
   background: $codeBlockBgColor;
+  overflow-x: auto;
+  position: relative; // needed for the copy code button
 }
 
 hr {

--- a/src/themes/hugo-theme-learn/assets/sass/_theme.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_theme.scss
@@ -521,15 +521,28 @@ code {
   border-radius: 3px;
   font-size: 85%;
   margin: 0;
+
+  h1 &,
+  h2 &,
+  h3 &,
+  h4 &,
+  h5 &,
+  a &,
+  {
+    background: transparent;
+    font-size: inherit;
+    padding: initial;
+    color: inherit;
+  }
 }
 
 pre {
   padding: 1rem;
-  margin: $paragraphSpacing * 1.5 0;
-  background: #f7f7f8;
+  margin: 0;
   border: 0;
   border-radius: 2px;
   line-height: 1.15;
+
 
   code {
     display: block;
@@ -541,6 +554,11 @@ pre {
     font-size: 14px;
     line-height: 1.45;
   }
+}
+
+div.highlight {
+  margin: $paragraphSpacing * 1.5 0;
+  background: $codeBlockBgColor;
 }
 
 hr {

--- a/src/themes/hugo-theme-learn/assets/sass/_theme.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/_theme.scss
@@ -1014,15 +1014,15 @@ pre {
 }
 
 #body {
-  a.highlight,
-  a.highlight:hover,
-  a.highlight:focus {
+  a,
+  a:hover,
+  a:focus {
     text-decoration: none;
     outline: none;
     outline: 0;
   }
 
-  a.highlight {
+  a {
     line-height: 1.1;
     display: inline-block;
 
@@ -1074,6 +1074,11 @@ pre {
   -webkit-transition: all 0.15s !important;
   -moz-transition: all 0.15s !important;
   transition: all 0.15s !important;
+
+  &:after {
+    // remove underline effect inherited from a
+    content: none !important;
+  }
 
   &:focus {
     outline: none !important;

--- a/src/themes/hugo-theme-learn/assets/sass/mixins/_variables.scss
+++ b/src/themes/hugo-theme-learn/assets/sass/mixins/_variables.scss
@@ -33,6 +33,8 @@ $menuSectionActiveCategoryBgColor: #fff; /* Color of background for the active c
 $menuVisitedColor: #ff3333; /* Color of 'page visited' icons in menu */
 $menuSectionHrColor: #2b2020; /* Color of <hr> separator in menu */
 
+$codeBlockBgColor: #f7f7f8;
+
 $tocBreakpoint: 1280px;
 
 $paragraphSpacing: 1rem; // vertical spacing below paragraphs

--- a/src/themes/hugo-theme-learn/static/js/learn.js
+++ b/src/themes/hugo-theme-learn/static/js/learn.js
@@ -175,7 +175,7 @@ jQuery(document).ready(function() {
 
     // clipboard
     var clipInit = false;
-    $('code').each(function() {
+    $('pre > code').each(function() {
         var code = $(this),
             text = code.text();
 

--- a/src/themes/hugo-theme-learn/static/js/learn.js
+++ b/src/themes/hugo-theme-learn/static/js/learn.js
@@ -247,7 +247,7 @@ jQuery(document).ready(function() {
       '#body-inner a:not(:has(img)):not(.btn):not(a[rel="footnote"])',
       '#toc a'
     ];
-    $(highlightables.join(', ')).addClass('highlight');
+    $(highlightables.join(', ')).addClass('highlight-words');
 
     /*var touchsupport = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)
     if (!touchsupport){ // browser doesn't support touch
@@ -378,7 +378,7 @@ jQuery.extend({
             var match = node.data.match(re);
             if (match) {
                 var highlight = document.createElement(nodeName || 'span');
-                highlight.className = className || 'highlight';
+                highlight.className = className || 'highlight-words';
                 var wordNode = node.splitText(match.index);
                 wordNode.splitText(match[0].length);
                 var wordClone = wordNode.cloneNode(true);
@@ -399,7 +399,7 @@ jQuery.extend({
 
 jQuery.fn.unhighlight = function(options) {
     var settings = {
-        className: 'highlight',
+        className: 'highlight-words',
         element: 'span'
     };
     jQuery.extend(settings, options);
@@ -413,7 +413,7 @@ jQuery.fn.unhighlight = function(options) {
 
 jQuery.fn.highlight = function(words, options) {
     var settings = {
-        className: 'highlight',
+        className: 'highlight-words',
         element: 'span',
         caseSensitive: false,
         wordsOnly: false


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR basically fixes small visual issues with horizontal scrolling in code blocks.<br>While I was doing that, I realized that the theme was using the `highlight` css class to highlight search results (no longer needed because we now use Algolia, but still), and this was conflicting with the same class being used by hugo in code blocks. I replaced `highlight` with `highlight-words`.<br>Also, the copy to clipboard button is no longer attached to inline code snippets.

Preview:
<img width="872" alt="Screenshot 2021-07-06 at 16 46 46" src="https://user-images.githubusercontent.com/1009343/124660028-09ffc480-de7c-11eb-85c2-25cabd8564b3.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
