### PR TITLE
Add code documentation and PHP type documentation to code standards

### DIFF
--- a/src/content/1.7/development/coding-standards/_index.md
+++ b/src/content/1.7/development/coding-standards/_index.md
@@ -21,6 +21,17 @@ All files containing code MUST:
 * Use the Unix LF (linefeed) line ending.
 * End with a single blank line.
 
+### Code documentation
+
+Make sure that **classes**, **attributes** and **methods** are properly documented using doc blocks, regardless of visibility. As a rule of thumb, consider that a developer should be able to understand a component and use it without even having to read the source code – signatures and doc blocks should suffice for most cases.
+
+Pay particular attention to the following:
+
+- **Describe the class's purpose.** If you have a hard time describing what the class is meant for, it may be a sign that it has too many responsibilites and needs to be decomposed.
+- **Describe intent, not implementation.** Explain what the method/class is for, not how it performs it—unless that information is important for the developer using it.
+- **Document attributes, parameters and return values both in type and semantics.** A variable named `$content` might be obviously a string, but we need more context to understand what its purpose is.
+- **It is preferable to waste time describing the obvious than to leave the ambiguous open to interpretation.** This prevents more bugs than you can imagine.
+
 ## PHP code conventions
 
 PHP files MUST follow the [PSR-2 standard](https://www.php-fig.org/psr/psr-2/) alongside [Symfony standards](https://symfony.com/doc/3.4/contributing/code/standards.html#structure).
@@ -39,6 +50,25 @@ php ./vendor/bin/php-cs-fixer fix
 ```
 
 The prestashop specific configuration file [can be found here](https://github.com/PrestaShop/PrestaShop/blob/develop/.php_cs.dist). Also, you can also use the provided [git pre-commit](https://github.com/PrestaShop/PrestaShop/tree/develop/.github/contrib) sample in order to make sure you never forget to make your code compliant!
+
+### Documenting types
+
+Parameters and return values SHOULD be described using Phpdoc as [documented by Phpstan](https://phpstan.org/writing-php-code/phpdoc-types), especially when the type cannot be strictly defined using PHP types (e.g. collections, structs, mixed types).
+
+Example:
+
+```php
+/**
+ * @var string[] Collection of IETF language tag (eg. "en-US")
+ */
+public $locales;
+```
+
+Particular attention should be paid to documenting arrays and array structures:
+
+- Use the simplified syntax for collections, like `string[]` or `SomeType[]`.
+- If the array's index is relevant (e.g., non-sequential), use the generics-style annotation, like `array<int, string>`.
+- If the array is actually a struct (i.e. an associative array whose schema is known), then it MUST be described it using the [array shape annotation](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes), like `array{'foo': int, "bar": string}`.
 
 ### Strict typing
 {{< minver v="1.7.7" title="true" >}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add code documentation and PHP type documentation to code standards

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
