### PR TITLE
Bump php version php7.1-fpm ==> php 7.3-fpm

### DIFF
--- a/src/content/1.7/basics/installation/nginx.md
+++ b/src/content/1.7/basics/installation/nginx.md
@@ -202,7 +202,7 @@ server {
 
         # [REQUIRED EDIT] Connection to PHP-FPM - choose one
         # fastcgi_pass 127.0.0.1:9000;
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.3-fpm.sock;
 
         fastcgi_keep_conn on;
         fastcgi_read_timeout 30s;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | I know that PHP 7.4 is coming in 1.7.8 really soon, still I had to do it.. PHP 7.1 is death since 1 Dec 2019. Next time maybe I will do some work on the NGINX configuration, getting old :)
| Fixed ticket? |  N/A


</td></tr></tbody><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
