### PR TITLE
How to generate URI with Symfony CSRF token

### DIFF
--- a/modules/concepts/controllers/admin-controllers/_index.md
+++ b/modules/concepts/controllers/admin-controllers/_index.md
@@ -169,8 +169,24 @@ your_route_name:
       _controller: 'MyModule\Controller\DemoController::demoAction'
       _disable_module_prefix: true
 ```
+## Generating URI of admin controller inside a module
+If you need to get the URI and security token of the controller you created inside the main module class, you need to get the router instance. Through that, you can get the URI with the function generate with the pathname as a parameter.
+Code example
+```
+# modules/your-module/your-module.php
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer; // add this to top of your file
 
 
+class YourModuleName extends Module 
+{
+    protected function generateControllerURI()
+    {
+           $router = SymfonyContainer::getInstance()->get('router');
+           return $router->generate("your_route_name")
+    }
+}
+
+```
 ## Secure your controller
 
 {{< minver v="1.7.5" title="true" >}}

--- a/modules/concepts/controllers/admin-controllers/_index.md
+++ b/modules/concepts/controllers/admin-controllers/_index.md
@@ -169,24 +169,31 @@ your_route_name:
       _controller: 'MyModule\Controller\DemoController::demoAction'
       _disable_module_prefix: true
 ```
-## Generating URI of admin controller inside a module
-If you need to get the URI and security token of the controller you created inside the main module class, you need to get the router instance. Through that, you can get the URI with the function generate with the pathname as a parameter.
-Code example
-```
-# modules/your-module/your-module.php
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer; // add this to top of your file
 
+### Generating the URI of a back-office controller inside a module
 
-class YourModuleName extends Module 
-{
-    protected function generateControllerURI()
+Valid URIs required a security token.
+
+In order to generate the valid URI of a controller you created from inside the main module class, you need to get the Symfony router. The router will build the URI using `generate` with the route name, as in the below example.
+
+```php
+    <?php
+    # modules/my-module/my-module.php
+
+    use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+
+    class MyModule extends Module
     {
-           $router = SymfonyContainer::getInstance()->get('router');
-           return $router->generate("your_route_name")
-    }
-}
+        protected function generateControllerURI()
+        {
+               $router = SymfonyContainer::getInstance()->get('router');
 
+               return $router->generate('my_route_name');
+        }
+    }
 ```
+
+
 ## Secure your controller
 
 {{< minver v="1.7.5" title="true" >}}


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Me and other developers had a hard time getting the right CSRF security token. I found out and was confused by two types of CSRF tokens that Prestashop uses. One of which is the regular token used by Prestashop admin controllers which has a nice way to generate and the other is the Symfony CSRF token which has little to no mention in Prestashop documentation. This token can be distinguished from the Prestashop token by the underscore before the word token (_token).  And you can generate through the router instance. I had a hard time finding out this, mainly because I am not really familiar with a lot of Symfony concepts and I think a lot of new developers will have the same problem. If this is not the correct way to do this change it but I highly recommend adding mention of this to admin controller documentation.
 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
