### PR TITLE
Test Pull Requests against devdocs-site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Test Build
+
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      TARGET_BRANCH: ${{ github.ref }}
+
+    steps:
+      - name: Checkout Hugo Site
+        uses: actions/checkout@v2
+        with:
+          repository: prestashop/devdocs-site
+          submodules: true
+
+      - name: Checkout PR
+        uses: actions/checkout@v2
+        with:
+          path: _current/
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.82.0'
+          extended: true
+
+      - name: Find version from branch name
+        # transform "refs/heads/1.7.x" in "1.7"
+        run: |
+          echo "VERSION=`echo $TARGET_BRANCH | perl -pe 's|^.+/([^/]+?)(?:\.x)?$|\1|'`" >> $GITHUB_ENV;
+          echo $VERSION
+
+      - name: Move content into the appropriate directory
+        run: |
+          [[ -d "src/content/$VERSION" ]] && rm -rf "src/content/$VERSION";
+          mv _current "src/content/$VERSION"
+
+      - name: Build
+        run: cd src/ && hugo


### PR DESCRIPTION
This change should allow us to verify that doc changes work with Hugo and won't break the build.

The script checks out both the PR and the prestashop/devdocs-site repo, moves the contents of the PR branch within the correct directory in Hugo, then runs the Hugo executable to find errors.
