### PR TITLE
Show a better way to push tag with alternative

### DIFF
--- a/project/maintainers-guide/releasing-prestashop/release-publicly.md
+++ b/project/maintainers-guide/releasing-prestashop/release-publicly.md
@@ -38,7 +38,9 @@ You can do this step using Git or directly on GitHub on the next step.
 - [Tag][git-tag] the new version:
     ```shell
     git tag 1.7.2.0 # replace by your version
-    git push --tags
+    git push 1.7.2.0 # replace by your version
+    # Alternatively (mainly to solve tag/branch name clashes), you could use
+    git push origin refs/tags/1.7.7.2
     ```
 
 ### Publish the release on GitHub


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Using `git push --tags` will push all tags created by the user on his local repository, it's a bad idea if you have a fork and you already play with tags. A simple `git push MY_VERSION` or if you have a branch already named like this, you can use `git push origin refs/tags/MY_VERSION` 
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
