### PR TITLE
Prohibition to use global variables for PS 8

### DIFF
--- a/modules/creation/good-practices.md
+++ b/modules/creation/good-practices.md
@@ -26,6 +26,7 @@ menuTitle: Good practices
 - Don't go through directories using code and variables like: `dirname(__FILE__).'/../../config/config.inc.php'`
 - Don't edit the SQL structure of PrestaShop tables.
 - Don't obfuscate your code, making it not human readable.
+- Don’t use global variables to avoid any conflict. Also global variables are usually considered a bad practice.
 
 ## A few recommendations for your modules
 

--- a/modules/creation/good-practices.md
+++ b/modules/creation/good-practices.md
@@ -26,7 +26,7 @@ menuTitle: Good practices
 - Don't go through directories using code and variables like: `dirname(__FILE__).'/../../config/config.inc.php'`
 - Don't edit the SQL structure of PrestaShop tables.
 - Don't obfuscate your code, making it not human readable.
-- Don’t use global variables to avoid any conflict. Also global variables are usually considered a bad practice.
+- Don't use global variables to avoid any conflict. Also global variables are usually considered a bad practice.
 
 ## A few recommendations for your modules
 


### PR DESCRIPTION
Added the prohibition to use global variables in modules, in accordance with the validator rules, for PS 8.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
