### PR TITLE
Update pr-branch-labeler to use pull_request_target

### DIFF
--- a/.github/workflows/pr-branch-labeler.yml
+++ b/.github/workflows/pr-branch-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Branch Labeler
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   label_prs:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | See below
| Fixed ticket? | 

## Description

For security reasons, the team at GitHub has decided to issue a GITHUB_TOKEN that has read-only access to the entire GitHub repository when the action is run from a fork. So the GA I added in PR cannot work https://github.com/PrestaShop/docs/pull/1143

Ref https://github.community/t/github-actions-are-severely-limited-on-prs/18179

GitHub provided a solution: the event `pull_request_target`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
