### PR TITLE
Webservice lib : fix wrong autoload file path 1.7.x

### DIFF
--- a/webservice/tutorials/prestashop-webservice-lib/setup-library.md
+++ b/webservice/tutorials/prestashop-webservice-lib/setup-library.md
@@ -41,7 +41,7 @@ The library is not PSR compliant and has no namespace therefore you need to upda
     },
     "autoload": {
         "files": [
-            "vendor/prestaShop/prestaShop-webservice-lib/PSWebServiceLibrary.php"
+            "vendor/prestashop/prestashop-webservice-lib/PSWebServiceLibrary.php"
         ]
     }
 }


### PR DESCRIPTION
case matters on GNU linux (at least).

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | fix case in autoload example
| Fixed ticket? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
