### PR TITLE
Fix Classic translation system documentation

### DIFF
--- a/modules/creation/module-translation/classic-system.md
+++ b/modules/creation/module-translation/classic-system.md
@@ -358,7 +358,7 @@ As you can see, there are three parameters:
         - The second argument to that function, if provided.
         - Your module's technical name, in lowercase, if not provided.
     - If the translation is performed in a `.tpl` file via `{l}` smarty tag:
-        - The file name, in lowercase, without the extension removed (eg. `foo.tpl` → `foo`)
+        - The file name, in lowercase, with the extension removed (eg. `foo.tpl` → `foo`)
     
 3. `$md5` – MD5 hash of the original wording you intend to translate.
 


### PR DESCRIPTION
Line 361, change "without the extension removed" to "with the extension removed"

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | The statement was ambiguous in Classic module translation system > Creating translation dictionary files > Editing a dictionary file manually
| Fixed ticket? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
