### PR TITLE
fix 2 tiny typo

### DIFF
--- a/development/architecture/domain/domain-services.md
+++ b/development/architecture/domain/domain-services.md
@@ -7,7 +7,7 @@ weight: 10
 
 As mentioned in [CQRS principles]({{< relref "./cqrs" >}}), a `Command` is a representation of a single domain use case. To prevent `Command Handlers` from duplicating code and depending on each other, it is usually best to **avoid implementing the actual logic in the `Command Handler`** itself, and delegate it to `Domain Services` instead. These services are responsible for logic such as:
 
-1. Persisting the entities (a.k.a ObjectModel in current prestashop architecture) data into database
+1. Persisting the entities (a.k.a. ObjectModel in current prestashop architecture) data into database
 2. Validating the entities
 3. Performing various modifications of related data structures etc.
 
@@ -19,7 +19,7 @@ Here are some principles for implementing a Domain Service:
 {{% notice %}}
    Some reusable methods are present in [AbstractObjectModelRepository](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/src/Adapter/AbstractObjectModelRepository.php).
 {{% /notice %}}
-4. If `ObjectModel` contains fields validation, it MUST be validated by a dedicated validator class before persisting to database (e.g. when using `add`/`update`/`save` methods). It ensures that lagacy [PrestashopException](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/exception/PrestaShopException.php) is not bubbling up and each validation error can be identified by a dedicated exception or exception code.
+4. If `ObjectModel` contains fields validation, it MUST be validated by a dedicated validator class before persisting to database (e.g. when using `add`/`update`/`save` methods). It ensures that legacy [PrestashopException](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/exception/PrestaShopException.php) is not bubbling up and each validation error can be identified by a dedicated exception or exception code.
 {{% notice %}}
    Some reusable methods are present in [AbstractObjectModelValidator](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/src/Adapter/AbstractObjectModelValidator.php).
 {{% /notice %}}


### PR DESCRIPTION
legacy + correct form for a.k.a. (final dot)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.7.x
| Description  | typos
| Fixed ticket | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
