### PR TITLE
override folder has to be writable

### DIFF
--- a/basics/installation/localhost.md
+++ b/basics/installation/localhost.md
@@ -175,6 +175,7 @@ PrestaShop needs recursive write permissions on several directories:
 - ./log
 - ./mails
 - ./modules
+- ./override
 - ./themes
 - ./translations
 - ./upload
@@ -182,7 +183,7 @@ PrestaShop needs recursive write permissions on several directories:
 
 You can set up the appropriate permissions using this command:
 ```bash
-$ chmod +w -R admin-dev/autoupgrade app/config app/logs app/Resources/translations cache config download img log mails modules themes translations upload var
+$ chmod +w -R admin-dev/autoupgrade app/config app/logs app/Resources/translations cache config download img log mails modules override themes translations upload var
 ```
 
 If you do not have some of the folders above, please create them before changing permissions. For example:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | override folder has to be writable : a lot of modules have override files that are copied in this folder at install.
| Fixed ticket? | 
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
