### PR TITLE
Fix wrong directory in CI when in pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    env:
-      TARGET_BRANCH: ${{ github.ref }}
-
     steps:
       - name: Checkout Hugo Site
         uses: actions/checkout@v2
@@ -26,11 +23,31 @@ jobs:
           hugo-version: '0.82.0'
           extended: true
 
-      - name: Find version from branch name
+      - name: Find version from branch name (pull request)
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          TARGET_BRANCH: ${{ github.base_ref }}
+        # transform "1.7.x" in "1.7"
+        run: |
+          echo "VERSION=`echo $TARGET_BRANCH | perl -pe 's|^([\d.]+)(?:\.x)?$|\1|'`" >> $GITHUB_ENV;
+
+      - name: Find version from branch name (push)
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          TARGET_BRANCH: ${{ github.ref }}
         # transform "refs/heads/1.7.x" in "1.7"
         run: |
           echo "VERSION=`echo $TARGET_BRANCH | perl -pe 's|^.+/([^/]+?)(?:\.x)?$|\1|'`" >> $GITHUB_ENV;
-          echo $VERSION
+
+      - name: Ensure the version is coherent
+        run: |
+          VERSION_FORMAT='^([0-9]+\.)*[0-9]+$'
+          if [[ ! $VERSION =~ $VERSION_FORMAT ]]; then
+            echo "::error::Version '$VERSION' is not a valid version!"
+            exit 1
+          else
+            echo "Version: '$VERSION'"
+          fi
 
       - name: Move content into the appropriate directory
         run: |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Fixed the directory used in CI when building for pull requests. Only push was working because github.ref is the name of the branch being buiolt, not the destination branch.
| Fixed ticket? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
