### PR TITLE
Add deprecated tag + add actionGetProductPropertiesAfterUnitPrice hook

### DIFF
--- a/modules/concepts/hooks/list-of-hooks.md
+++ b/modules/concepts/hooks/list-of-hooks.md
@@ -628,7 +628,7 @@ actionGetIDZoneByAddressID
     
 actionGetProductPropertiesAfter
 : 
-    **(deprecated since 1.7.8)**
+    **(deprecated since 1.7.8 in favor of)**
     → `actionGetProductPropertiesAfterUnitPrice`
 
     Located in: /classes/Product.php

--- a/modules/concepts/hooks/list-of-hooks.md
+++ b/modules/concepts/hooks/list-of-hooks.md
@@ -628,6 +628,9 @@ actionGetIDZoneByAddressID
     
 actionGetProductPropertiesAfter
 : 
+    **(deprecated since 1.7.8)**
+    → `actionGetProductPropertiesAfterUnitPrice`
+
     Located in: /classes/Product.php
 
     
@@ -2743,5 +2746,11 @@ actionAfterCreate&lt;FormName>FormHandler
         'id' => $id,
     ]
     ```
+
+actionGetProductPropertiesAfterUnitPrice
+: 
+    Available since: {{< minver v="1.7.8" >}}
+
+    Located in: /classes/Product.php
 
 {{% /funcdef %}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Add deprecated tag to actionGetProductPropertiesAfter hook and add the actionGetProductPropertiesAfterUnitPrice hook.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
