### PR TITLE
Update broken 404 links to github points 1.7.6.x -> 1.7.8.0

### DIFF
--- a/modules/concepts/controllers/front-controllers.md
+++ b/modules/concepts/controllers/front-controllers.md
@@ -43,7 +43,7 @@ automatically.
 
 ## Available properties
 
-The controllers added in a module extend [`ModuleFrontController`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/controller/ModuleFrontController.php), itself extending [`FrontController`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/controller/FrontController.php) & [`Controller`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/controller/Controller.php).
+The controllers added in a module extend [`ModuleFrontController`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.0/classes/controller/ModuleFrontController.php), itself extending [`FrontController`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.0/classes/controller/FrontController.php) & [`Controller`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.0/classes/controller/Controller.php).
 They provide access to the environment in which they run.
 
 * `$this->module` is the instance of the module responsible of the controller.

--- a/modules/concepts/controllers/front-controllers.md
+++ b/modules/concepts/controllers/front-controllers.md
@@ -43,7 +43,7 @@ automatically.
 
 ## Available properties
 
-The controllers added in a module extend [`ModuleFrontController`](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.x/classes/controller/ModuleFrontController.php), itself extending [`FrontController`](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.x/classes/controller/FrontController.php) & [`Controller`](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.x/classes/controller/Controller.php).
+The controllers added in a module extend [`ModuleFrontController`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/controller/ModuleFrontController.php), itself extending [`FrontController`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/controller/FrontController.php) & [`Controller`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/controller/Controller.php).
 They provide access to the environment in which they run.
 
 * `$this->module` is the instance of the module responsible of the controller.


### PR DESCRIPTION
links to GitHub points to 1.7.6.x which doesn't exist anymore.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | 404 not found - fix links that points to 1.7.8.x branch instead of 1.7.6.x which is removed from GH
| Fixed ticket? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
