### PR TITLE
Updating context of where code goes

### DIFF
--- a/modules/creation/displaying-content-in-front-office.md
+++ b/modules/creation/displaying-content-in-front-office.md
@@ -43,6 +43,8 @@ Attaching code to a hook requires a specific method for each:
     `hookDisplayLeftColumn()`, but for the right column.
 -   `hookActionFrontControllerSetMedia()`: will add a link to the module's CSS file,
     `/views/css/mymodule.css` and module's JS file, `/views/js/mymodule.js`.
+    
+Add the following to your mymodule.php file:
 
 ```php
 <?php


### PR DESCRIPTION
It's not clear that we are still working with the mymodule.php file because the code block starts with a new <?php block which tricked me into thinking that we were in a new file. I added a line to make sure it's known to work in the mymodule.php file.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
