### PR TITLE
fix docker hub links

### DIFF
--- a/modules/testing/resources.md
+++ b/modules/testing/resources.md
@@ -10,9 +10,9 @@ weight: 10
 Docker isolate your application in containers, making their isolation and deployment easier.
 If you're confident with using it, we created several images for easier deployment of PrestaShop:
 
-* https://hub.docker.com/r/prestashop/prestashop/, in which all PrestaShop releases between 1.4 and 1.7 can be found. Covers most needs and is perfect for a quick start.
-* https://hub.docker.com/r/prestashop/prestashop-git/, containing the git repository content with different PHP version. For advanced users.
-* https://hub.docker.com/r/prestashop/base/, containing the required stack to run PrestaShop, without the core files. Recommended if you already have the shop files on your disk.
+* https://hub.docker.com/r/prestashop/prestashop/ , in which all PrestaShop releases between 1.4 and 1.7 can be found. Covers most needs and is perfect for a quick start.
+* https://hub.docker.com/r/prestashop/prestashop-git/ , containing the git repository content with different PHP version. For advanced users.
+* https://hub.docker.com/r/prestashop/base/ , containing the required stack to run PrestaShop, without the core files. Recommended if you already have the shop files on your disk.
 
 Please note we try to follow best practices, and MySQL service is NOT provided with these images. You have to deploy your own server in a dedicated container.
 

--- a/modules/testing/resources.md
+++ b/modules/testing/resources.md
@@ -10,9 +10,9 @@ weight: 10
 Docker isolate your application in containers, making their isolation and deployment easier.
 If you're confident with using it, we created several images for easier deployment of PrestaShop:
 
-* https://hub.docker.com/r/prestashop/prestashop/ , in which all PrestaShop releases between 1.4 and 1.7 can be found. Covers most needs and is perfect for a quick start.
-* https://hub.docker.com/r/prestashop/prestashop-git/ , containing the git repository content with different PHP version. For advanced users.
-* https://hub.docker.com/r/prestashop/base/ , containing the required stack to run PrestaShop, without the core files. Recommended if you already have the shop files on your disk.
+* [https://hub.docker.com/r/prestashop/prestashop/](https://hub.docker.com/r/prestashop/prestashop/), in which all PrestaShop releases between 1.4 and 1.7 can be found. Covers most needs and is perfect for a quick start.
+* [https://hub.docker.com/r/prestashop/prestashop-git/](https://hub.docker.com/r/prestashop/prestashop-git/), containing the git repository content with different PHP version. For advanced users.
+* [https://hub.docker.com/r/prestashop/base/](https://hub.docker.com/r/prestashop/base/), containing the required stack to run PrestaShop, without the core files. Recommended if you already have the shop files on your disk.
 
 Please note we try to follow best practices, and MySQL service is NOT provided with these images. You have to deploy your own server in a dedicated container.
 


### PR DESCRIPTION
links contain the comma, which lead to an almost blank page on dockerhub

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x 
| Description?  | Fix links
| Fixed ticket? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
