### PR TITLE
Color picker is coming to v8, not 1.7.9

### DIFF
--- a/development/components/global-components.md
+++ b/development/components/global-components.md
@@ -80,7 +80,7 @@ MultistoreConfigField        | 1.7.8
 PreviewOpener                | 1.7.8
 Router                       | 1.7.8
 Grid                         | 1.7.8
-ColorPicker                  | 1.7.9
+ColorPicker                  | 8.0.0
 
 ## Grid component
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | No need to backport
| Fixed ticket? | Fixes #{issue number here} if there is a related issue
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
