### PR TITLE
Update contribute_using_localhost.md

### DIFF
--- a/contribute/contribute-pull-requests/contribute_using_localhost.md
+++ b/contribute/contribute-pull-requests/contribute_using_localhost.md
@@ -80,6 +80,8 @@ cd /path/to/prestashop
 composer install
 ```
 
+You may need to edit `PHP.ini` to add or uncomment PHP extensions `extension=gd` and `extension=intl`.
+
 ### Compile assets
 
 Static assets are not present in the repository and need to be compiled (we explained why in [this article](https://build.prestashop.com/news/open-question-not-commiting-assets-anymore/)).


### PR DESCRIPTION
Suggest to add PHP extensions (gd and intl) in PHP.ini which are needed in order for `composer install` to work.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x
| Description?  | Suggest to add PHP extensions (gd and intl) in PHP.ini which are needed in order for `composer install` to work.
| Fixed ticket? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
