### PR TITLE
Update localhost.md

### DIFF
--- a/basics/installation/localhost.md
+++ b/basics/installation/localhost.md
@@ -150,7 +150,7 @@ make composer
 ### JavaScript and CSS dependencies
 
 PrestaShop uses NPM to manage dependencies and [Webpack][webpack] to compile them into static assets. 
-You only need NodeJS 8.x (12.x maximum [get it here][nodejs]), NPM will take care of it all.
+You only need NodeJS 8.x (14.x recommended [get it here][nodejs]), NPM will take care of it all.
 
 ```bash
 cd /path/to/prestashop


### PR DESCRIPTION
Changed NodeJS v12 maximum to NodeJs v14.x recommended.

To match requirement stated in this page
https://devdocs.prestashop.com/8/development/compile-assets/

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | It said to use NodeJS v12 maximum, changed to NodeJS v14.x recommended to match requirement stated in page https://devdocs.prestashop.com/8/development/compile-assets/
| Fixed ticket? | NONE

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
