### PR TITLE
Fix "chmod" syntax in installation DevDocs

### DIFF
--- a/basics/installation/localhost.md
+++ b/basics/installation/localhost.md
@@ -183,7 +183,7 @@ PrestaShop needs recursive write permissions on several directories:
 
 You can set up the appropriate permissions using this command:
 ```bash
-$ chmod +w -R admin-dev/autoupgrade app/config app/logs app/Resources/translations cache config download img log mails modules override themes translations upload var
+$ chmod -R +w admin-dev/autoupgrade app/config app/logs app/Resources/translations cache config download img log mails modules override themes translations upload var
 ```
 
 If you do not have some of the folders above, please create them before changing permissions. For example:


### PR DESCRIPTION
```
Both: GNU coreutils and FreeBSD expect specifying chmod options before a
mode argument. In case of FreeBSD reverted order makes chmod ignore
recursive option and complain about missing file:

chmod: -R: No such file or directory

Use correct chmod arguments order to help developers installing
PrestaShop on FreeBSD.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Fix "chmod" syntax in installation DevDocs
| Fixed ticket? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
