### PR TITLE
Improve actionValidateOrderAfter doc, adding missing var and since info

### DIFF
--- a/modules/concepts/hooks/list-of-hooks.md
+++ b/modules/concepts/hooks/list-of-hooks.md
@@ -1133,7 +1133,9 @@ actionValidateOrder
     ```
 
 actionValidateOrderAfter
-:   
+: 
+    Available since: {{< minver v="8.0.0" >}}
+
     This hook is called after validating an order by core
 
     Located in: /classes/PaymentModule.php
@@ -1144,6 +1146,7 @@ actionValidateOrderAfter
     array(
       'cart' => (object) Cart,
       'order' => (object) Order,
+      'orders' => (array) $order_list,
       'customer' => (object) Customer,
       'currency' => (object) Currency,
       'orderStatus' => (object) OrderState


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Add missing var inside the parameters and add the since version.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
