### PR TITLE
Remove actionValidateOrderAfter from hooks listing

### DIFF
--- a/modules/concepts/hooks/list-of-hooks.md
+++ b/modules/concepts/hooks/list-of-hooks.md
@@ -1134,24 +1134,6 @@ actionValidateOrder
     );
     ```
 
-actionValidateOrderAfter
-:   
-    This hook is called after validating an order by core
-
-    Located in: /classes/PaymentModule.php
-
-    Parameters:
-    ```php
-    <?php
-    array(
-      'cart' => (object) Cart,
-      'order' => (object) Order,
-      'customer' => (object) Customer,
-      'currency' => (object) Currency,
-      'orderStatus' => (object) OrderState
-    );
-    ```
-
 actionValidateStepComplete
 : 
     This hook is called on checkout page, when confirming delivery section. Carrier modules that display extra content to the customer can hook here and prevent him from advancing further, if he didn't enter required information. 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | As the hook is not available inside PrestaShop 1.7, we don't need to have it inside the list.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
