### PR TITLE
Add displayAdminOrderCreateExtraButtons hook

### DIFF
--- a/modules/concepts/hooks/list-of-hooks.md
+++ b/modules/concepts/hooks/list-of-hooks.md
@@ -205,7 +205,15 @@ actionAdminOrdersTrackingNumberUpdate
       'carrier' => (Carrier)
     );
     ```
+
+displayAdminOrderCreateExtraButtons
+: 
+    Available since: {{< minver v="1.7.8" >}}
     
+    Add buttons on the create order page dropdown
+    
+    Located in: src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+
 actionAdminProductsListingFieldsModifier
 : 
     Located in: /src/Adapter/Product/AdminProductDataProvider.php


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Add missing `displayAdminOrderCreateExtraButtons` hook
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
