### PR TITLE
`updateProduct` & `updatedProduct` events should have different descriptions

### DIFF
--- a/themes/reference/javascript-events/_index.md
+++ b/themes/reference/javascript-events/_index.md
@@ -76,7 +76,7 @@ Event Name            | Description
  `changedCheckoutStep` | Each checkout step **submission** will fire this event.
  `updateProductList`  | On every product list page (category, search results, pricedrop and so on), the list is updated via ajax calls if you change filters or sorting options. Each time the DOM is reloaded with new product list, this event is triggered.
  `clickQuickView`     | If your theme handles it, this event will be trigged when you click on the quickview link.
- `updateProduct`      | On the product page, selecting a new combination will reload the DOM via ajax calls. After the update, this event is fired.
+ `updateProduct`      | On the product page, selecting a new combination will reload the DOM via ajax calls. This event will fire after modifying the combination, but before the ajax call.
  `updatedProduct`      | On the product page, selecting a new combination will reload the DOM via ajax calls. After the update, this event is fired.
  `handleError`        | This event is fired after a fail of POST request. Have the `eventType` as first parameter.
  `updateFacets`        | On every product list page (category, search results, pricedrop and so on), the list is updated via ajax calls if you change filters or sorting options. Each time the facets is reloaded, this event is triggered.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | updateProduct & updatedProduct events have the exact same description !!!??


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
