### PR TITLE
Changed database structure version number to the latest one

### DIFF
--- a/development/database/structure.md
+++ b/development/database/structure.md
@@ -9,7 +9,7 @@ weight: 4
 
 ### Global definition
 
-The database structure of PrestaShop can be found in `install/data/db_structure.sql` ([1.7.3.x releases example](https://github.com/PrestaShop/PrestaShop/blob/1.7.3.x/install-dev/data/db_structure.sql)).
+The database structure of PrestaShop can be found in `install/data/db_structure.sql` ([1.7.8.x releases example](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/install-dev/data/db_structure.sql)).
 
 It is used one time, during the installation of PrestaShop.
 It contains the structure of almost all tables. If a table needs to be added or


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.7.8
| Description | Changed database structure version number to the latest one. However, this is not a definitive solution to the problem. There should be a link that points allways to the current /structure.md -file, so the link doesn't need to be changed every time a new version is published.?

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
