### PR TITLE
Remove anchor part of link symfony doc for forms as service

### DIFF
--- a/development/architecture/migration-guide/forms/_index.md
+++ b/development/architecture/migration-guide/forms/_index.md
@@ -65,7 +65,7 @@ Most of the components from the PrestaShop UI Kit are implemented as Form Types.
 Before creating a new form type, check this folder first to see if the type already exists.
 {{% /notice %}}
 
-Forms are created and declared [as services](https://symfony.com/doc/4.4/form/form_dependencies.html#define-your-form-as-a-service) that you can use inside your Controllers – this is covered in the [Controllers/Routing section][controllers-and-routing] of this guide.
+Forms are created and declared [as services](https://symfony.com/doc/4.4/form/form_dependencies.html) that you can use inside your Controllers – this is covered in the [Controllers/Routing section][controllers-and-routing] of this guide.
 
 ## Learn more
 


### PR DESCRIPTION
There's no more section "define your form as a service" in this symfony version.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | remove uselless anchor part in link to symfony doc
| Fixed ticket? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
