### PR TITLE
Fix hook actionPresentCart parameter indentation

### DIFF
--- a/modules/concepts/hooks/list-of-hooks.md
+++ b/modules/concepts/hooks/list-of-hooks.md
@@ -1227,57 +1227,57 @@ actionPresentCart
        'presentedCart' => array(
             'products' => (ProductLazyArray|ProductListingLazyArray) $products,
             'totals' => array(
-	        'total' => array(
-		    'type' => 'total'
+	            'total' => array(
+		            'type' => 'total'
                     'label' => Price label
                     'amount' => Price amount
                     'value' => Price formatted
-		),
-		'total_including_tax' => array(
-		    'type' => 'total_including_tax'
+		        ),
+		        'total_including_tax' => array(
+		            'type' => 'total_including_tax'
                     'label' => Price label
                     'amount' => Price amount
                     'value' => Price formatted
-		),
-		'total_excluding_tax' => array(
-		    'type' => 'total_excluding_tax'
+		        ),
+		        'total_excluding_tax' => array(
+		            'type' => 'total_excluding_tax'
                     'label' => Price label
                     'amount' => Price amount
                     'value' => Price formatted
-		),
-	    ),
+		        ),
+	        ),
             'subtotals' => array(
-	        'products' => array(
-		    'type' => 'products'
+	            'products' => array(
+		            'type' => 'products'
                     'label' => Price label
                     'amount' => Price amount
                     'value' => Price formatted
-		),
-		'discounts' => array(
-		    'type' => 'discounts'
+		        ),
+		        'discounts' => array(
+		            'type' => 'discounts'
                     'label' => Price label
                     'amount' => Price amount
                     'value' => Price formatted
-		),
-		'gift_wrapping' => array(
-		    'type' => 'gift_wrapping'
+		        ),
+		        'gift_wrapping' => array(
+		            'type' => 'gift_wrapping'
                     'label' => Price label
                     'amount' => Price amount
                     'value' => Price formatted
-		),
-		'shipping' => array(
-		    'type' => 'shipping'
+		        ),
+		        'shipping' => array(
+		            'type' => 'shipping'
                     'label' => Price label
                     'amount' => Price amount
                     'value' => Price formatted
-		),
-		'tax' => array(
-		    'type' => 'tax'
+		        ),
+		        'tax' => array(
+		            'type' => 'tax'
                     'label' => Price label
                     'amount' => Price amount
                     'value' => Price formatted
-		),
-	    ),
+		        ),
+	        ),
             'products_count' => (int) Number of products in cart,
             'summary_string' => (string) Descriptive number of products,
             'labels' => array(

--- a/modules/concepts/hooks/list-of-hooks.md
+++ b/modules/concepts/hooks/list-of-hooks.md
@@ -1227,7 +1227,7 @@ actionPresentCart
        'presentedCart' => array(
             'products' => (ProductLazyArray|ProductListingLazyArray) $products,
             'totals' => array(
-	            'total' => array(
+                'total' => array(
 		            'type' => 'total'
                     'label' => Price label
                     'amount' => Price amount


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Fix bad hook actionPresentCart parameters indentation
| Fixed ticket? | Fixes https://github.com/PrestaShop/docs/issues/1276

### Before

![Capture d’écran 2022-01-25 à 11 44 45](https://user-images.githubusercontent.com/3830050/150963070-d16875b7-0190-49ef-9f64-db3df95ef48b.png)

### After

![Capture d’écran 2022-01-25 à 11 44 33](https://user-images.githubusercontent.com/3830050/150963049-49db15fd-3c7d-45f0-bcb7-ccf7f9dafa8f.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
