### PR TITLE
Please clarify the correct way to autoload Commands added by modules

### DIFF
--- a/faq/modules.md
+++ b/faq/modules.md
@@ -1,0 +1,59 @@
+---
+title: Modules FAQ
+---
+
+# Modules FAQ
+
+[module-commands]: {{< ref "/1.7/modules/concepts/commands" >}}
+
+**Q:** How do i add a command to an existing module, with autoloading?
+
+**A:** [In the modules section of the documentation, about module commands][module-commands], the instructions are assuming the module is installed via composer. In case you follow the same procedure but wish to add the command in your already existing module in `modules/<module_directory>` then the procedure requires an extra step. 
+
+For example with a structure like this:
+
+```tree
+modules/module_directory/
+├── config
+│   └── services.yml
+├── config.xml
+├── module_directory.php
+├── src
+│   └── Command
+│       └── SyncCommand.php
+```
+
+You would also need to namespace your src directory in `composer.json` located in the base directory of your project, by appending the following:
+
+```
+    "autoload": {
+        "psr-4": {
+            "PrestaShop\\PrestaShop\\": "src/",
+            "PrestaShopBundle\\": "src/PrestaShopBundle/",
+            "Vendor\\Module\\": "modules/module_directory/src/"
+        },
+        "classmap": [
+            "app/AppKernel.php",
+            "app/AppCache.php"
+        ]
+    },
+```
+
+And follow through using the correct namespaces throught your module commands. 
+
+**Predefined Constants**: If you would like to use existing PS constants like `_DB_PREFIX_` you also need to require the file `config/config.inc.php` 
+
+e.g. 
+
+```php
+$basePath = realpath(__DIR__ . '/../../../../');
+require_once $basePath . '/config/config.inc.php';
+```
+
+**Loading Module Classes**: Commands by default won't have module classes loaded. You need to explicitly require the modules before you can use their classes
+
+e.g. 
+
+```php
+require_once _PS_MODULE_DIR_ . '/<module_directory>/<module_directory>.php';
+```        

--- a/faq/modules.md
+++ b/faq/modules.md
@@ -6,11 +6,11 @@ title: Modules FAQ
 
 [module-commands]: {{< ref "/1.7/modules/concepts/commands" >}}
 
-**Q:** How do i add a command to an existing module, with autoloading?
+**Q:** How do I add a command to an existing module with autoloading?
 
-**A:** [In the modules section of the documentation, about module commands][module-commands], the instructions are assuming the module is installed via composer. In case you follow the same procedure but wish to add the command in your already existing module in `modules/<module_directory>` then the procedure requires an extra step. 
+**A:** [In the modules section of the documentation, about module commands][module-commands], the instructions assume the module is installed via Composer. If you follow the same procedure but wish to add the command in your existing module in `modules/<module_directory>`, then the procedure requires an extra step. 
 
-For example with a structure like this:
+For example, with a structure like this:
 
 ```tree
 modules/module_directory/
@@ -23,7 +23,7 @@ modules/module_directory/
 │       └── SyncCommand.php
 ```
 
-You would also need to namespace your src directory in `composer.json` located in the base directory of your project, by appending the following:
+You would also need to namespace your `src` directory in `composer.json` located in the base directory of your project, by appending the following:
 
 ```
     "autoload": {
@@ -39,9 +39,9 @@ You would also need to namespace your src directory in `composer.json` located i
     },
 ```
 
-And follow through using the correct namespaces throught your module commands. 
+And follow through using the correct namespaces throughout your module commands. 
 
-**Predefined Constants**: If you would like to use existing PS constants like `_DB_PREFIX_` you also need to require the file `config/config.inc.php` 
+**Predefined Constants**: If you would like to use existing PS constants like `_DB_PREFIX_`, you also need to require the file `config/config.inc.php`. 
 
 e.g. 
 
@@ -50,7 +50,7 @@ $basePath = realpath(__DIR__ . '/../../../../');
 require_once $basePath . '/config/config.inc.php';
 ```
 
-**Loading Module Classes**: Commands by default won't have module classes loaded. You need to explicitly require the modules before you can use their classes
+**Loading Module Classes**: Commands, by default, won't have module classes loaded. You must require the module's main file before using their classes.
 
 e.g. 
 

--- a/modules/concepts/commands.md
+++ b/modules/concepts/commands.md
@@ -77,6 +77,66 @@ services:
 
 The command should be now available using `./bin/console your-module:export`.
 
+
+### Autoloading
+
+The instructions above are assuming the module is installed via composer. In case you follow the same procedure but wish to add the command in your already existing module in `modules/<module_directory>` then the procedure requires an extra step. 
+
+For example with a structure like this 
+
+```tree
+modules/module_directory/
+├── config
+│   └── services.yml
+├── config.xml
+├── module_directory.php
+├── src
+│   └── Command
+│       └── SyncCommand.php
+```
+
+You would also need to namespace your src directory in `docroot/composer.json`
+
+By appending the following 
+
+```
+    "autoload": {
+        "psr-4": {
+            "PrestaShop\\PrestaShop\\": "src/",
+            "PrestaShopBundle\\": "src/PrestaShopBundle/",
+            "Vendor\\Module\\": "modules/module_directory/src/"
+        },
+        "classmap": [
+            "app/AppKernel.php",
+            "app/AppCache.php"
+        ]
+    },
+```
+
+And follow through using the correct namespaces throught your module commands. 
+
+### Predefined Constants
+
+If you would like to use existing PS constants like `_DB_PREFIX_` you also need to require the file `config/config.inc.php` 
+
+e.g. 
+
+```php
+$basePath = realpath(__DIR__ . '/../../../../');
+require_once $basePath . '/config/config.inc.php';
+```
+
+### Loading Module Classes 
+
+Commands by default won't have module classes loaded. You need to explicitly require the modules before you can use their classes
+
+e.g. 
+
+```php
+require_once $basePath . '/modules/<module_directory>/<module_directory>.php';
+```        
+        
+
 ## Learn more about the PrestaShop Console
 
 We use the Symfony Console with nothing specific to PrestaShop.

--- a/modules/concepts/commands.md
+++ b/modules/concepts/commands.md
@@ -77,66 +77,6 @@ services:
 
 The command should be now available using `./bin/console your-module:export`.
 
-
-### Autoloading
-
-The instructions above are assuming the module is installed via composer. In case you follow the same procedure but wish to add the command in your already existing module in `modules/<module_directory>` then the procedure requires an extra step. 
-
-For example with a structure like this 
-
-```tree
-modules/module_directory/
-├── config
-│   └── services.yml
-├── config.xml
-├── module_directory.php
-├── src
-│   └── Command
-│       └── SyncCommand.php
-```
-
-You would also need to namespace your src directory in `docroot/composer.json`
-
-By appending the following 
-
-```
-    "autoload": {
-        "psr-4": {
-            "PrestaShop\\PrestaShop\\": "src/",
-            "PrestaShopBundle\\": "src/PrestaShopBundle/",
-            "Vendor\\Module\\": "modules/module_directory/src/"
-        },
-        "classmap": [
-            "app/AppKernel.php",
-            "app/AppCache.php"
-        ]
-    },
-```
-
-And follow through using the correct namespaces throught your module commands. 
-
-### Predefined Constants
-
-If you would like to use existing PS constants like `_DB_PREFIX_` you also need to require the file `config/config.inc.php` 
-
-e.g. 
-
-```php
-$basePath = realpath(__DIR__ . '/../../../../');
-require_once $basePath . '/config/config.inc.php';
-```
-
-### Loading Module Classes 
-
-Commands by default won't have module classes loaded. You need to explicitly require the modules before you can use their classes
-
-e.g. 
-
-```php
-require_once $basePath . '/modules/<module_directory>/<module_directory>.php';
-```        
-        
-
 ## Learn more about the PrestaShop Console
 
 We use the Symfony Console with nothing specific to PrestaShop.


### PR DESCRIPTION
I'm adding the steps I had to do to actually make the command accessible and working on our Prestashop 1.7.5.2 installation as I could find no other documentation on the proper procedure apart from a sample module that can be installed via a custom repository. Unfortunately that way of installing wasn't possible in our case and we had to work with an existing legacy module that needed to append a new console command for handling extensively long cron tasks. 

This is documentation purely based on experience on our installation and maybe it will help others looking to do the same. It doesn't mean it's the proper way, it's the only way I could find by experience to make things work. 

If there's a suggested way of doing it, please scratch this out and write it so that we can use everything correctly in the recommended way.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x
| Description?  | The documentation is not very intuitive and I struggled for hours to make it work. That's why I enhanced by describing my experience with this area of Prestashop
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
