### PR TITLE
Fix link 404 on ressource test page

### DIFF
--- a/modules/testing/resources.md
+++ b/modules/testing/resources.md
@@ -144,4 +144,4 @@ PrestaShop provides its own test suite, running with puppeteer. It covers the fe
 
 These tests are launched every time a change is suggested to the core, but you can also run them with your module installed. This will ensure your module code does not break a critical feature of the core.
 
-This section will be completed when these tests will be available on a dedicated repository. In the meantime you can already reach them on GitHub, in the [tests/puppeteer folder](https://github.com/PrestaShop/PrestaShop/tree/1.7.7.x/tests/puppeteer) of PrestaShop files.
+This section will be completed when these tests will be available on a dedicated repository. In the meantime you can already reach them on GitHub, in the [tests/puppeteer folder](https://github.com/PrestaShop/PrestaShop/tree/1.7.7.x/tests/UI) of PrestaShop files.

--- a/modules/testing/resources.md
+++ b/modules/testing/resources.md
@@ -144,4 +144,4 @@ PrestaShop provides its own test suite, running with puppeteer. It covers the fe
 
 These tests are launched every time a change is suggested to the core, but you can also run them with your module installed. This will ensure your module code does not break a critical feature of the core.
 
-This section will be completed when these tests will be available on a dedicated repository. In the meantime you can already reach them on GitHub, in the [tests/puppeteer folder](https://github.com/PrestaShop/PrestaShop/tree/1.7.7.x/tests/UI) of PrestaShop files.
+This section will be completed when these tests will be available on a dedicated repository. In the meantime you can already reach them on GitHub, in the [tests/UI](https://github.com/PrestaShop/PrestaShop/tree/1.7.7.x/tests/UI) of PrestaShop files.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | On this page https://devdocs.prestashop.com/1.7/modules/testing/resources/ (docs/modules/testing/resources.md) on "Core Functional tests" there is a 404 link on "tests/puppeteer folder".
| Fixed ticket? | Fixes #1261 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
