### PR TITLE
Fix `DbQuery` class `limit` method signature.

### DIFF
--- a/development/components/database/dbquery.md
+++ b/development/components/database/dbquery.md
@@ -58,7 +58,7 @@ leftOuterJoin(string $table, string $alias = null, string $on = null)
 : 
     Add a LEFT OUTER JOIN clause.
 
-limit(string $limit, mixed $offset = 0)
+limit(int $limit, int $offset = 0)
 : 
     Limit results in query.
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | See https://github.com/PrestaShop/PrestaShop/blob/develop/classes/db/DbQuery.php#L259-L267
| Fixed ticket? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
