### PR TITLE
fix(doc): updated modulefrontcontroller doc

### DIFF
--- a/modules/concepts/controllers/front-controllers.md
+++ b/modules/concepts/controllers/front-controllers.md
@@ -58,12 +58,14 @@ There are basically two kinds of HTTP calls possible for a controller:
 * Calls with GET, used to only retrieve data,
 * Calls with POST, used as soon as some data is modified on the shop.
 
+For an advanced use, others HTTP methods can also be called ( such as PUT, PATCH, DELETE ).
+
 Depending of the request made to the controller, a different method will be
 called by the core.
 
-### Display content (GET)
+### Display content
 
-Handling GET requests can be done by implementing the method `initContent()` in
+Handling requests can be done by implementing the method `initContent()` in
 the front controller. Note the parent class also implements it, do not forget
 to call it as well.
 


### PR DESCRIPTION
* Others HTTP methods can be called in a Module Front Controller, the documentation seems to pretends it's restricted to GET & POST methods.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | updating documentation to avoid misunderstanding of HTTP method useable in ModuleFrontController childs.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
