### PR TITLE
Add hint about var/cache folder for upgrade

### DIFF
--- a/basics/keeping-up-to-date/upgrade.md
+++ b/basics/keeping-up-to-date/upgrade.md
@@ -95,7 +95,7 @@ release content in the existing shop.
 
 ### Disable cache
 
-You may have activated a caching system (eg. memcache) on your shop. In that case, make sure to disable it in "Advanced Parameters" > "Performance". You can enable it again once the upgrade process is done.
+You may have activated a caching system (eg. memcache) on your shop. In that case, make sure to disable it in "Advanced Parameters" > "Performance". You can enable it again once the upgrade process is done. Please don't forget to also delete the var/cache/prod and var/cache/dev folders.
 
 **Note about `vendor` folder**: Previous upgrades of PrestaShop 1.7
 showed that conflicts may occur when merging the new vendor/ folder with

--- a/basics/keeping-up-to-date/upgrade.md
+++ b/basics/keeping-up-to-date/upgrade.md
@@ -95,7 +95,7 @@ release content in the existing shop.
 
 ### Disable cache
 
-You may have activated a caching system (eg. memcache) on your shop. In that case, make sure to disable it in "Advanced Parameters" > "Performance". You can enable it again once the upgrade process is done. You might want to also delete the var/cache/prod and var/cache/dev folders.
+You may have activated a caching system (eg. memcache) on your shop. In that case, make sure to disable it in "Advanced Parameters" > "Performance". You can enable it again once the upgrade process is done. You might want to also delete the `var/cache/prod` and `var/cache/dev` folders.
 
 **Note about `vendor` folder**: Previous upgrades of PrestaShop 1.7
 showed that conflicts may occur when merging the new vendor/ folder with

--- a/basics/keeping-up-to-date/upgrade.md
+++ b/basics/keeping-up-to-date/upgrade.md
@@ -95,7 +95,7 @@ release content in the existing shop.
 
 ### Disable cache
 
-You may have activated a caching system (eg. memcache) on your shop. In that case, make sure to disable it in "Advanced Parameters" > "Performance". You can enable it again once the upgrade process is done. Please don't forget to also delete the var/cache/prod and var/cache/dev folders.
+You may have activated a caching system (eg. memcache) on your shop. In that case, make sure to disable it in "Advanced Parameters" > "Performance". You can enable it again once the upgrade process is done. You might want to also delete the var/cache/prod and var/cache/dev folders.
 
 **Note about `vendor` folder**: Previous upgrades of PrestaShop 1.7
 showed that conflicts may occur when merging the new vendor/ folder with


### PR DESCRIPTION
Just tried an upgrade, and got an error, resolved cleaning the cache dir. I think that deleting those folders should be in the Upgrade manual page.

```
devshop@hosting:~/httpdocs$ /opt/plesk/php/7.2/bin/php install/upgrade/upgrade.php
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider::__construct() must be of the type array, object given, called in /var/www/vhosts/shop.example.com/httpdocs/var/cache/prod/ContainerYovgajs/appProdProjectContainer.php on line 2181 in /var/www/vhosts/shop.example.com/httpdocs/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php:59
Stack trace:
#0 /var/www/vhosts/shop.example.com/httpdocs/var/cache/prod/ContainerYovgajs/appProdProjectContainer.php(2181): PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider->__construct(Object(PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient), Object(Symfony\Bridge\Monolog\Logger), Array, Array)
#1 /var/www/vhosts/shop.example.com/httpdocs/var/cache/prod/ContainerYovgajs/appProdProjectContainer.php(2191): ContainerYovgajs\appProdProjectContainer->getPrestashop_CategoriesProviderService()
#2 /var/www/vhosts/shop in /var/www/vhosts/shop.example.com/httpdocs/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php on line 59
```