### PR TITLE
Give an example on how to handle translation of Javascript strings.

### DIFF
--- a/development/internationalization/translation/using-the-translator.md
+++ b/development/internationalization/translation/using-the-translator.md
@@ -106,6 +106,13 @@ If you have have replacements to peform in your wording, then there are two opti
     <div>{l s='There are %products_count% items in your cart.' sprintf=['%products_count%' => $cart.products_count] d='Shop.Theme.Checkout'}</div>
     ```
 
+**Note:** The `l` macro does not support escaping the strings for javascript. Instead you can assign the translation to a variable and escape it afterwards:
+
+    ```html
+    {assign var='translatedString' value={l s='Text containing single quote' d='Modules.Mymodule.Shop'}}
+    <script>var text='{$translatedString|escape:'javascript'}';</script>
+    ```
+
 ## Twig templates
 
 In `.twig` files, you can use the `trans` filter from Twig:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Give an example on how to handle translation of Javascript strings in smarty templates.
| Fixed ticket? | Fixes #1342

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
