### PR TITLE
Module error with namespace Foo\Repository

### DIFF
--- a/modules/concepts/hooks/use-hooks-on-modern-pages.md
+++ b/modules/concepts/hooks/use-hooks-on-modern-pages.md
@@ -281,4 +281,5 @@ We have used a key for translation, making our own translations available in bac
 
 And "voila!", the module could be of course improved with so many features, adding filters on export for instance, using the `request` hook parameter and updating the Product repository.
 
-[setup-composer]: {{< ref "/1.7/modules/concepts/composer/#setup-composer-in-a-module" >}}
+[setup-composer]: {{< ref "/1.7/modules/concepts/composer/_index.md" >}}
+

--- a/modules/concepts/hooks/use-hooks-on-modern-pages.md
+++ b/modules/concepts/hooks/use-hooks-on-modern-pages.md
@@ -153,24 +153,9 @@ Prestashop automatically checks if modules have a `config/services.yml` file and
 ```
 ./bin/console cache:clear --no-warmup
 ```
-In case Prestashop failed to autoload automatically, make autoload with composer manually:
 
-- Install composer if you don't have https://getcomposer.org/
+In case Prestashop failed to autoload automatically, [you can generate the autoload files][setup-composer] with composer manually.
 
-- Create inside the module's folder the file named composer.json and insert the below code
-```
-{
-  "autoload": {
-    "psr-4": {
-      "Foo\\": "classes/"
-    }
-  }
-}
-```
-- Open your terminal then go to your module folder and launch this command: 
-``` 
-php composer.phar dump-autoload -a
-```
 This will generate a vendor folder, with inside composer folder and autoload.php file.
 
 You can now use it in your module (and everywhere in PrestaShop modern pages!):
@@ -295,3 +280,5 @@ We have used a key for translation, making our own translations available in bac
 ![Export XML action button](https://i.imgur.com/5HExjcC.png)
 
 And "voila!", the module could be of course improved with so many features, adding filters on export for instance, using the `request` hook parameter and updating the Product repository.
+
+[setup-composer]: {{< ref "/1.7/modules/concepts/composer/#setup-composer-in-a-module" >}}

--- a/modules/concepts/hooks/use-hooks-on-modern-pages.md
+++ b/modules/concepts/hooks/use-hooks-on-modern-pages.md
@@ -153,6 +153,25 @@ Prestashop automatically checks if modules have a `config/services.yml` file and
 ```
 ./bin/console cache:clear --no-warmup
 ```
+In case Prestashop failed to autoload automatically, make autoload with composer manually:
+
+- Install composer if you don't have https://getcomposer.org/
+
+- Create inside the module's folder the file named composer.json and insert the below code
+```
+{
+  "autoload": {
+    "psr-4": {
+      "Foo\\": "classes/"
+    }
+  }
+}
+```
+- Open your terminal then go to your module folder and launch this command: 
+``` 
+php composer.phar dump-autoload -a
+```
+This will generate a vendor folder, with inside composer folder and autoload.php file.
 
 You can now use it in your module (and everywhere in PrestaShop modern pages!):
 


### PR DESCRIPTION
Solution for the warning: Attempted to load class "ProductRepository" from namespace "Foo\Repository". Did you forget a "use" statement for another namespace?
following https://stackoverflow.com/questions/52933943/prestashop-1-7-4-module-error-with-namespace

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
