### PR TITLE
Fix link to composer page

### DIFF
--- a/modules/concepts/commands.md
+++ b/modules/concepts/commands.md
@@ -31,7 +31,7 @@ You need to create the file and register it as a "command".
 
 First you need to setup your composer file, you will find more info about it in [Setup composer][setup-composer]
 
-[setup-composer]: {{< ref "/1.7/modules/concepts/services/_index.md#setup-composer" >}}
+[setup-composer]: {{< ref "/1.7/modules/concepts/composer/_index.md" >}}
 
 ### Creation of the command
 


### PR DESCRIPTION
Currently the composer link goes to a non-existing area in the services page. This moves the link to the composer page.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
