### PR TITLE
Addresses webservice spelling fix

### DIFF
--- a/webservice/tutorials/testing-access.md
+++ b/webservice/tutorials/testing-access.md
@@ -93,7 +93,7 @@ Let's see what they look like for the `address` resource.
 
 ### Blank schema
 
-`/api/adresses?schema=blank`
+`/api/addresses?schema=blank`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -128,7 +128,7 @@ Let's see what they look like for the `address` resource.
 
 ### Synopsis schema
 
-`/api/adresses?schema=synopsis`
+`/api/addresses?schema=synopsis`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
missing a 'd' character make wrong link

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | The address webservice URL was wrong

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
