### PR TITLE
Fix minor typo and path order

### DIFF
--- a/modules/concepts/hooks/use-hooks-on-modern-pages.md
+++ b/modules/concepts/hooks/use-hooks-on-modern-pages.md
@@ -38,7 +38,7 @@ Accessing the Product Catalog page in *debug mode* we can access the list of ava
 * actionAdminControllerSetMedia
 * displayDashboardToolbarTopMenu
 * displayDashboardTop
-* hookdisplayDashboardToolbarIcons
+* displayDashboardToolbarIcons
 * displayBackOfficeFooter
 * displayAdminNavBarBeforeEnd
 * displayAdminAfterHeader
@@ -265,7 +265,7 @@ We have extracted business logic into specific functions.
 And now, the template:
 
 ```twig
-{# in views/Foo/download_link.twig #}
+{# in Foo/views/download_link.twig #}
 <a id="desc-product-export" class="list-toolbar-btn" href="{{ filepath }}" download>
   <b data-toggle="pstooltip" class="label-tooltip" data-original-title="{{ "Export XML"|trans({}, 'Module.Foo') }}" data-html="true" data-placement="top">
     <i class="material-icons">cloud_upload</i>


### PR DESCRIPTION
1. Remove redundant word from hook name
2. Correct path order: module name, then views

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x
| Description?  | Fix for the correct hook name and twig file's path in module
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
