### PR TITLE
Fix old link to https://cs.sensiolabs.org/ 

### DIFF
--- a/development/coding-standards/_index.md
+++ b/development/coding-standards/_index.md
@@ -42,7 +42,7 @@ Although [Yoda conditions](https://en.wikipedia.org/wiki/Yoda_conditions) are su
 
 ### Making your code follow our coding standards
 
-[PHP CS Fixer](https://cs.sensiolabs.org/) has been configured for the PrestaShop project to help developers to comply with these conventions.
+[PHP CS Fixer](https://cs.symfony.com/) has been configured for the PrestaShop project to help developers to comply with these conventions.
 
 You can run it using the following command:
 ```bash


### PR DESCRIPTION
Fix link to PHP CS Fixer

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Old link https://cs.sensiolabs.org/ - does not exist. 
| Fixed ticket? | none?

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
