### PR TITLE
Remove extraCarrier note, as it's deprecated since 1.7.0 and not used

### DIFF
--- a/modules/carrier/_index.md
+++ b/modules/carrier/_index.md
@@ -13,10 +13,6 @@ A carrier module is a regular PrestaShop module, except that it extends the Carr
 class MyOwnCarrier extends CarrierModule
 ```
 
-It can be attached to the following hooks:
-
-* `extraCarrier`: to display the shipping price depending on the ranges that were set in the back office.
-
 A carrier module must use the following methods:
 
 * `getOrderShippingCost()`: to compute the shipping price depending on the ranges that were set in the back office.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Since 1.7.0, the hooks (extraCarrier and it's alias displayCarrierList) are deprecated and it's use are removed later. (https://github.com/PrestaShop/PrestaShop/pull/12808/files).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
