### PR TITLE
Update jQuery version regarding PrestaShop 1.7.8

### DIFF
--- a/themes/getting-started/theme-organization.md
+++ b/themes/getting-started/theme-organization.md
@@ -127,6 +127,7 @@ add a comment indicating where the code related to products can be found ;)
 
 #### Required libraries
 
-jQuery v3.4 is loaded by the core (bundled in `core.js`) file.
+jQuery v3.4 (v3.5 since {{< minver v="1.7.8" title="true" >}}) is loaded by the core (bundled in `core.js`) file.
+
 
 Read more about [assets management]({{< relref "/8/themes/getting-started/asset-management/" >}}).


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | jQuery version was updated inside 1.7.8

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
