### PR TITLE
Fix broken image link after PR 1428 merged

### DIFF
--- a/basics/installation/localhost.md
+++ b/basics/installation/localhost.md
@@ -109,7 +109,7 @@ PrestaShop comes in two "flavors":
 - **Release package**. A zip package, tuned for production environments.
 - **Development version**. The raw source code as it is on the GitHub repository, including automated test suites, build scripts and source codes for assets that are otherwise compiled (like javascript and css files).
 
-![Download files](/basics/installation/img/Prestashop_1.7.8.6_release.png)
+![Download files](../img/Prestashop_1.7.8.6_release.png)
 
 {{% notice tip %}}
 **Prefer cloning the repository using git for the development version.**

--- a/basics/installation/localhost.md
+++ b/basics/installation/localhost.md
@@ -109,7 +109,7 @@ PrestaShop comes in two "flavors":
 - **Release package**. A zip package, tuned for production environments.
 - **Development version**. The raw source code as it is on the GitHub repository, including automated test suites, build scripts and source codes for assets that are otherwise compiled (like javascript and css files).
 
-![Download files](img/Prestashop_1.7.8.6_release.png)
+![Download files](/basics/installation/img/Prestashop_1.7.8.6_release.png)
 
 {{% notice tip %}}
 **Prefer cloning the repository using git for the development version.**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Source /localhost.md becomes Target /localhost/ so Relative ref img/Prestashop_1.7.8.6_release.png on Source need ../ prefix to work on Target.
| Fixed ticket? | Fixes #1432

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
