### PR TITLE
Remove extra -v of classname modifier output

### DIFF
--- a/development/components/smarty-extensions/_index.md
+++ b/development/components/smarty-extensions/_index.md
@@ -205,7 +205,7 @@ It will:
 ...will output:
 
 ```
-  here-is-a-classname-v
+  here-is-a-classname
 ```
 
 #### classnames


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | There is an extra -v into the ouput.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
