### PR TITLE
Wrong path in the folders for SF migrated pages in introduction.md

### DIFF
--- a/basics/introduction.md
+++ b/basics/introduction.md
@@ -126,9 +126,9 @@ The legacy backend relies on controllers which you can find in the directory `co
 
 For legacy pages, the views and the Javascript can be found in `admin-dev/themes/default`.
 
-The Symfony backend relies on the controllers you can find in `templates/bundles/PrestaShopBundle/Controller/Admin` and PrestaShop logic that mostly comes from the `src` folder, and also some `classes` files.
+The Symfony backend relies on the controllers you can find in `src/PrestaShopBundle/Controller/Admin` and PrestaShop logic that mostly comes from the `src` folder, and also some `classes` files.
 
-For migrated pages, you can find the views in `templates/bundles/PrestaShopBundle/Resources/views`.
+For migrated pages, you can find the views in `src/PrestaShopBundle/Resources/views/Admin`.
 The Javascript can be found in `admin-dev/themes/new-theme/js`.
 
 ### Visit a legacy Back Office controller


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Wrong path
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
