### PR TITLE
Fix jQuery version

### DIFF
--- a/themes/reference/javascript-events/_index.md
+++ b/themes/reference/javascript-events/_index.md
@@ -19,7 +19,7 @@ A default store loads two important files on every page:
   `theme.js`| Bundles all theme specific code and libraries
 
 {{% notice tip %}}
-  jQuery is loaded by the core, so each theme will have jQuery v2 available. Do not redefine it.
+  jQuery is loaded by the core, so each theme will have jQuery v3 available. Do not redefine it.
 {{% /notice %}}
 
 ## Events


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Before, in the array of included files, the version is the v3. (It's the v3.5.1)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
