### PR TITLE
Update reference.md

### DIFF
--- a/webservice/reference.md
+++ b/webservice/reference.md
@@ -16,7 +16,7 @@ Most resources can be accessed in a REST manner, with the 5 main HTTP request me
 | Key                            | GET | POST | PUT | DELETE | HEAD |
 |--------------------------------|:---:|:----:|:---:|:------:|:----:|
 | search                         | ✅  |      |     |        | ✅   |
-| stock_availables               | ✅  | ✅   |     |        | ✅   |
+| stock_availables               | ✅  |      | ✅  |        | ✅   |
 | stock_movements                | ✅  |      |     |        | ✅   |
 | stocks                         | ✅  |      |     |        | ✅   |
 | supply_order_details           | ✅  |      |     |        | ✅   |


### PR DESCRIPTION
For Prestashop 1.7.8.6
classes/webservice/WebserviceRequest.php:329:
'stock_availables' => ['description' => 'Available quantities', 'class' => 'StockAvailable', 'forbidden_method' => ['POST', 'DELETE']],

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Because documentation doesn't reflect the code. There is more then a year old question about it on Prestashop Forum <https://www.prestashop.com/forums/topic/1051455-cannot-use-post-methode-with-the-ressource-stock_availables/>
| Fixed ticket? | -