### PR TITLE
Fix usage of underscores in new translation system page (Backported #1279)

### DIFF
--- a/modules/creation/module-translation/new-system.md
+++ b/modules/creation/module-translation/new-system.md
@@ -322,12 +322,12 @@ You can distribute the downloaded dictionaries by placing the extracted files in
 .
 └── mymodule/
     └── translations/
-        ├── fr_FR/
-        │   ├── ModulesMymoduleFoo.fr_FR.xlf
-        │   └── ModulesMymoduleBar.fr_FR.xlf
-        └── en_US/
-            ├── ModulesMymoduleFoo.en_US.xlf
-            └── ModulesMymoduleBar.en_US.xlf
+        ├── fr-FR/
+        │   ├── ModulesMymoduleFoo.fr-FR.xlf
+        │   └── ModulesMymoduleBar.fr-FR.xlf
+        └── en-US/
+            ├── ModulesMymoduleFoo.en-US.xlf
+            └── ModulesMymoduleBar.en-US.xlf
 ```
 
 {{% notice warning %}}


### PR DESCRIPTION
You have incorrectly used underscores instead of hyphens

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Backport of issue [1279](https://github.com/PrestaShop/docs/pull/1279)

