### PR TITLE
Add a title to the list of Smarty variables (Backported 1305)

### DIFF
--- a/modules/creation/displaying-content-in-front-office.md
+++ b/modules/creation/displaying-content-in-front-office.md
@@ -410,6 +410,9 @@ simple names, such as `{$products}`, and to prefix it with your module's
 name, or even your own name or initials, such as:
 `{$henryb_mymodule_products}`.
 
+List of Smarty variables
+---------------------------------
+
 Here is a list of Smarty variables that are common to all template pages:
 
 


### PR DESCRIPTION
Backport of 1305 :

Add a title to the List of Smarty variables.
It's a very frequent google query and this part should be seo optimized.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x
| Description?  | Backport of [1305](https://github.com/PrestaShop/docs/pull/1305)
