### PR TITLE
Addresses webservice spelling fix (Backported #1377)

### DIFF
--- a/webservice/tutorials/testing-access.md
+++ b/webservice/tutorials/testing-access.md
@@ -91,7 +91,7 @@ Let's see what they look like for the `address` resource.
 
 ### Blank schema
 
-`/api/adresses?schema=blank`
+`/api/addresses?schema=blank`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -126,7 +126,7 @@ Let's see what they look like for the `address` resource.
 
 ### Synopsis schema
 
-`/api/adresses?schema=synopsis`
+`/api/addresses?schema=synopsis`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
missing a 'd' character make wrong link

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Backport of #1377 - missing a 'd' character make wrong link
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
