### PR TITLE
Remove a wrong link in democqrshooksusage module

### DIFF
--- a/modules/sample-modules/grid-and-identifiable-object-form-hooks-usage.md
+++ b/modules/sample-modules/grid-and-identifiable-object-form-hooks-usage.md
@@ -175,7 +175,7 @@ Route name `ps_democqrshooksusage_toggle_is_allowed_for_review` matches the one 
 ### Extending grid query builder
 
 By just extending grid definition we won't be able to display any data since we need to fetch it first. Luckily, we can add additional sql
-conditions by extending [doctrine's query builder](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/query-builder.html).
+conditions by extending [doctrine's query builder](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/query-builder.html).
 
 ```php
 <?php

--- a/modules/sample-modules/grid-and-identifiable-object-form-hooks-usage.md
+++ b/modules/sample-modules/grid-and-identifiable-object-form-hooks-usage.md
@@ -341,6 +341,3 @@ private function updateCustomerReviewStatus(array $params)
 when we created the switch type form we named it `is_allowed_for_review`. By using the same name we can get the state (on or off).
 This hook receives from `$params` the form data, that you can retrieve like this: `$params['form_data']`.
 All the form data is available here, including `is_allowed_for_review` data which comes from the switch.
-
-You can find example module here: 
-https://github.com/PrestaShop/example-modules/tree/master/demoextendsymfonyform2


### PR DESCRIPTION
Correct link was `noticed` 3 times above

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | demoextendsymfonyform2 is Form with upload image field
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
