### PR TITLE
Fix inconsistency link between MarkDown and HugoServer for PR 1430

### DIFF
--- a/modules/concepts/hooks/use-hooks-on-modern-pages.md
+++ b/modules/concepts/hooks/use-hooks-on-modern-pages.md
@@ -182,7 +182,7 @@ public function hookDisplayDashboardToolbarIcons($hookParams)
 
 In Product Catalog Page you should see the list of Products in debug toolbar in "Dump" section:
 
-![Get products in Dump section](./Catalog_Products_dump.png)
+![Get products in Dump section](../Catalog_Products_dump.png)
 
 #### Using the Symfony components to create an XML export file
 
@@ -284,7 +284,7 @@ And now, the template:
 We have used a key for translation, making our own translations available in back office when using Twig.
 {{% /notice %}}
 
-![Export XML action button](./Catalog_Products_2xml.png)
+![Export XML action button](../Catalog_Products_2xml.png)
 
 And "voila!", the module could be of course improved with so many features, adding filters on export for instance, using the `request` hook parameter and updating the Product repository.
 


### PR DESCRIPTION
./ can not solve inconsistency. We still need 1 level jump up with ../ to make image links work in HugoServer :(

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Fix inconsistency link between MarkDown and HugoServer for PR #1430
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
