### PR TITLE
Update classic theme changes in PrestaShop 8

### DIFF
--- a/themes/reference/templates/notifications.md
+++ b/themes/reference/templates/notifications.md
@@ -33,7 +33,7 @@ An array of notification is passed to the templates, containing at least one of 
 
 ## How to display notifications
 
-In the "Classic" Theme, [notifications are implemented as a partial template file](https://github.com/PrestaShop/classic-theme/blob/develop/templates/_partials/notifications.tpl):
+In the "Classic" Theme, [notifications are implemented as a partial template file](https://github.com/PrestaShop/classic-theme/blob/2.0.1/templates/_partials/notifications.tpl):
 
 ```smarty
 <aside id="notifications">

--- a/themes/reference/templates/notifications.md
+++ b/themes/reference/templates/notifications.md
@@ -89,7 +89,7 @@ In the "Classic" Theme, [notifications are implemented as a partial template fil
 </aside>
 ```
 
-...and are then [included in the template file](https://github.com/PrestaShop/classic-theme/blob/develop/templates/customer/page.tpl#L32-L34):
+...and are then [included in the template file](https://github.com/PrestaShop/classic-theme/blob/2.0.1/templates/customer/page.tpl#L32-L34):
 
 ```smarty
 {block name='notifications'}

--- a/themes/reference/templates/notifications.md
+++ b/themes/reference/templates/notifications.md
@@ -33,7 +33,7 @@ An array of notification is passed to the templates, containing at least one of 
 
 ## How to display notifications
 
-In the "Classic" Theme, [notifications are implemented as a partial template file](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.0/themes/classic/templates/_partials/notifications.tpl):
+In the "Classic" Theme, [notifications are implemented as a partial template file](https://github.com/PrestaShop/classic-theme/blob/develop/templates/_partials/notifications.tpl):
 
 ```smarty
 <aside id="notifications">
@@ -89,7 +89,7 @@ In the "Classic" Theme, [notifications are implemented as a partial template fil
 </aside>
 ```
 
-...and are then [included in the template file](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.0/themes/classic/templates/checkout/checkout.tpl#L46-L48):
+...and are then [included in the template file](https://github.com/PrestaShop/classic-theme/blob/develop/templates/customer/page.tpl#L32-L34):
 
 ```smarty
 {block name='notifications'}


### PR DESCRIPTION
Classic theme is moved out of core, <br>
and checkout.tpl does not include notifications.tpl

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
