### PR TITLE
Fix release lifecycle links

### DIFF
--- a/project/release/minor-release-lifecycle.md
+++ b/project/release/minor-release-lifecycle.md
@@ -98,4 +98,4 @@ The global duration for all the process is about 6 months. This is why we expect
 
 
 _(This article was originally published on our blog: [PrestaShop 1.7 Minor Release Lifecycle
-](https://build.prestashop.com/news/ps17-patch-release-lifecycle/))_
+](https://build.prestashop.com/news/ps17-minor-release-lifecycle/))_

--- a/project/release/patch-release-lifecycle.md
+++ b/project/release/patch-release-lifecycle.md
@@ -50,4 +50,4 @@ If the campaign reports that no bugs are found, the new patch release is validat
 
 
 _(This article was originally published on our blog: [PrestaShop 1.7 Patch Release Lifecycle
-](https://build.prestashop.com/news/ps17-minor-release-lifecycle/))_
+](https://build.prestashop.com/news/ps17-patch-release-lifecycle/))_


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | I noticed the link on page "Patch release lifecycle" targets the blog "Minor release lifecycle" and the link on page "Minor release lifecycle" targets the blog "Patch release lifecycle". It's inversed.
| Fixed ticket? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
