### PR TITLE
Change urls from build.prestashop.com to build.prestashop-project.org for 8.x

### DIFF
--- a/basics/keeping-up-to-date/_index.md
+++ b/basics/keeping-up-to-date/_index.md
@@ -13,7 +13,7 @@ The purpose of this chapter is to provide the best practices and tips for keepin
 Keeping a shop updated to the latest available version ensures you have the latest changes brought by the core team and the developer community.
 Depending on the version you upgrade to, you can get new features, security or performance improvements, or simply bug fixes.
 
-Furthermore, the support of PrestaShop 1.6 [is now ended](https://build.prestashop.com/news/1.6.1.x-what-s-next/). We recommend using recent PrestaShop versions to get support, along with core and modules upgrades.
+Furthermore, the support of PrestaShop 1.6 [is now ended](https://build.prestashop-project.org/news/1.6.1.x-what-s-next/). We recommend using recent PrestaShop versions to get support, along with core and modules upgrades.
 
 ## Upgrade and migration, two different processes
 

--- a/contribute/contribute-pull-requests/_index.md
+++ b/contribute/contribute-pull-requests/_index.md
@@ -29,7 +29,7 @@ If you have trouble using this flow, you can find out more at [GitHub help](http
 While it may seem complex, this flow is the standard way most open source projects use to handle contributions. [This article](https://dev.to/mathieuks/introduction-to-github-fork-workflow-why-is-it-so-complex-3ac8) about the flow can help you understand the reasons for each part of the process.
 
 {{% notice tip %}}
-If you wish to start contributing smoothly, have a look at [issues labelled "good first issue"](https://github.com/PrestaShop/PrestaShop/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and pick one to work with. This label lists all beginner-friendly bugs and improvements. Read more about this label on [Build](https://build.prestashop.com/news/a-definition-of-the-good-first-issue-label).
+If you wish to start contributing smoothly, have a look at [issues labelled "good first issue"](https://github.com/PrestaShop/PrestaShop/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and pick one to work with. This label lists all beginner-friendly bugs and improvements. Read more about this label on [Build](https://build.prestashop-project.org/news/a-definition-of-the-good-first-issue-label).
 {{% /notice %}}
 
 ## In this section

--- a/contribute/contribute-pull-requests/contribute_using_localhost.md
+++ b/contribute/contribute-pull-requests/contribute_using_localhost.md
@@ -82,7 +82,7 @@ composer install
 
 ### Compile assets
 
-Static assets are not present in the repository and need to be compiled (we explained why in [this article](https://build.prestashop.com/news/open-question-not-commiting-assets-anymore/)).
+Static assets are not present in the repository and need to be compiled (we explained why in [this article](https://build.prestashop-project.org/news/open-question-not-commiting-assets-anymore/)).
 You will need `npm` installed on your environment (here is the documentation about [how to compile assets][compile-assets]), then you can simply run:
 
 ```bash

--- a/contribute/contribution-process/how-issues-are-sorted.md
+++ b/contribute/contribution-process/how-issues-are-sorted.md
@@ -32,7 +32,7 @@ Examples:
 - Difficulty to globally manage categories, products or customers
 - Difficulty to globally place and manage orders
 
-A critical issue should result in a patch version that should be released as soon as possible. [PrestaShop 1.7.2.5](https://build.prestashop.com/news/prestashop-1-7-2-5-maintenance-release/) is a good example: this patch release fixes two vulnerabilities affecting the Back Office.
+A critical issue should result in a patch version that should be released as soon as possible. [PrestaShop 1.7.2.5](https://build.prestashop-project.org/news/prestashop-1-7-2-5-maintenance-release/) is a good example: this patch release fixes two vulnerabilities affecting the Back Office.
 
 
 ### Major
@@ -98,4 +98,4 @@ In the end, handling bugs requires two points of view: micro and macro. Severity
 
 ---
 
-_(This article was originally published on our blog: [Introducing A New Bug Severity Classification](https://build.prestashop.com/news/severity-classification/))_
+_(This article was originally published on our blog: [Introducing A New Bug Severity Classification](https://build.prestashop-project.org/news/severity-classification/))_

--- a/contribute/contribution-process/how-pull-requests-are-processed.md
+++ b/contribute/contribution-process/how-pull-requests-are-processed.md
@@ -30,7 +30,7 @@ The results of these checks is displayed at the bottom of the Pull Request. Some
 
 For example he detects mistakes in the pull request description, he add some labels to classify the pull requests, he welcomes new contributors to the project ...
 
-[Read his article for the full details.](https://build.prestashop.com/news/prestonbot-reaches-stable-version/)
+[Read his article for the full details.](https://build.prestashop-project.org/news/prestonbot-reaches-stable-version/)
 
 If something is wrong, Prestonbot will write a comment in the pull request to tell you what to fix.
 
@@ -83,4 +83,4 @@ After the Pull Request has finally passed the QA validation, it is merged in the
 
 ---
 
-_(This article was originally published on our blog: [What Happens To Pull Requests After They Are Submitted](https://build.prestashop.com/news/the-review-process/))_
+_(This article was originally published on our blog: [What Happens To Pull Requests After They Are Submitted](https://build.prestashop-project.org/news/the-review-process/))_

--- a/development/architecture/introduction.md
+++ b/development/architecture/introduction.md
@@ -10,7 +10,7 @@ summary: "Learn how PrestaShop is structured: back-end, front-end, business stac
 PrestaShop is a big project, with several moving parts. In this article you will learn how they are structured and how they work together.
  
 {{% notice note %}}
-Part of this article was originally published in 2019 as a [blog post](https://build.prestashop.com/news/prestashop-in-2019-and-beyond-part-1-current-architecture/). It has been updated and adapted for documentation purposes here.
+Part of this article was originally published in 2019 as a [blog post](https://build.prestashop-project.org/news/prestashop-in-2019-and-beyond-part-1-current-architecture/). It has been updated and adapted for documentation purposes here.
 {{% /notice %}}
 
 ## Overview
@@ -231,7 +231,7 @@ This means that the global interface is handled by the **default** theme, _even 
 
 Rest assured, this is a _temporary issue_ which will be solved when everything has been migrated to Twig and Symfony.
 
-[introducing-symfony]: http://build.prestashop.com/news/prestashop-1-7-and-symfony/
+[introducing-symfony]: http://build.prestashop-project.org/news/prestashop-1-7-and-symfony/
 {{% /callout %}}
 
 Finally, there's [Vue pages][introducing-vue]. Vue pages are hybrid: half-Symfony, half-API based BO pages. In those pages, the page's skeleton is first rendered by a Symfony controller (therefore, based on the **new theme**), and then a VueJS application takes over in the browser and draws its content based on data sent by the BO API.
@@ -281,12 +281,12 @@ Remember the overview at the top of the article? Have a look at this more detail
 
 [SSOT]: https://en.wikipedia.org/wiki/Single_source_of_truth
 [vuejs]: https://vuejs.org/
-[introduction]: https://build.prestashop.com/news/prestashop-in-2019-and-beyond-introduction/
-[architecture-1610]: https://build.prestashop.com/news/new-architecture-1-6-1-0/
-[child-themes]: https://build.prestashop.com/news/Child-Themes-Feature/
-[uikit]: https://build.prestashop.com/news/PrestaShop-UI-Kit/
-[introducing-vue]: https://build.prestashop.com/news/introducing-vuejs-symfony-api/
-[future-architecture]: https://build.prestashop.com/news/prestashop-in-2019-and-beyond-part-3-the-future-architecture/
+[introduction]: https://build.prestashop-project.org/news/prestashop-in-2019-and-beyond-introduction/
+[architecture-1610]: https://build.prestashop-project.org/news/new-architecture-1-6-1-0/
+[child-themes]: https://build.prestashop-project.org/news/Child-Themes-Feature/
+[uikit]: https://build.prestashop-project.org/news/PrestaShop-UI-Kit/
+[introducing-vue]: https://build.prestashop-project.org/news/introducing-vuejs-symfony-api/
+[future-architecture]: https://build.prestashop-project.org/news/prestashop-in-2019-and-beyond-part-3-the-future-architecture/
 [SOLID]: https://en.wikipedia.org/wiki/SOLID
 [adapter-pattern]: https://sourcemaking.com/design_patterns/adapter
 [dependency-inversion]: https://en.wikipedia.org/wiki/Dependency_inversion_principle

--- a/development/architecture/migration-guide/strategy.md
+++ b/development/architecture/migration-guide/strategy.md
@@ -165,7 +165,7 @@ Our Handlers started as "place where we put the legacy code we dont have the tim
 [adapter-namespace]: {{< ref "/8/development/architecture/file-structure/understanding-src-folder.md" >}}
 [cqrs]: {{< ref "/8/development/architecture/domain/cqrs.md" >}}
 [domain]: https://en.wikipedia.org/wiki/Domain-driven_design
-[future-architecture]: https://build.prestashop.com/news/prestashop-in-2019-and-beyond-part-3-the-future-architecture/#our-proposal-for-a-future-architecture
+[future-architecture]: https://build.prestashop-project.org/news/prestashop-in-2019-and-beyond-part-3-the-future-architecture/#our-proposal-for-a-future-architecture
 [ubiquitous-langage]: https://enterprisecraftsmanship.com/posts/ubiquitous-language-naming/
 [vue-js]: https://vuejs.org/
 [twig-form-theme]: {{< ref "/8/development/components/form/form-theme/" >}}

--- a/development/architecture/migration-guide/templating-with-twig.md
+++ b/development/architecture/migration-guide/templating-with-twig.md
@@ -67,7 +67,7 @@ label_with_help(label, help)
 
 ## Bootstrap
 
-Legacy templates use [Bootstrap 3](https://getbootstrap.com/docs/3.3/) while modern pages use the [PrestaShop UI Kit](https://build.prestashop.com/prestashop-ui-kit/) that is based on [Bootstrap 4](https://getbootstrap.com/docs/4.0/getting-started/introduction/). This means that you'll need to update some markup (especially CSS classes).
+Legacy templates use [Bootstrap 3](https://getbootstrap.com/docs/3.3/) while modern pages use the [PrestaShop UI Kit](https://build.prestashop-project.org/prestashop-ui-kit/) that is based on [Bootstrap 4](https://getbootstrap.com/docs/4.0/getting-started/introduction/). This means that you'll need to update some markup (especially CSS classes).
 
 {{% notice tip %}}
 If you aren't familiar with Bootstrap 4, check out their [article on migrating to v4](https://getbootstrap.com/docs/4.0/migration/), which explains the major changes from v3 to v4.

--- a/development/page-reference/back-office/order/view-order/refunds/_index.md
+++ b/development/page-reference/back-office/order/view-order/refunds/_index.md
@@ -6,7 +6,7 @@ menuTitle: Refunds
 # Cancellations and refunds
 
 {{% notice info %}}
-For a full specification of how these features work, you can read [the functional specifications](https://build.prestashop.com/prestashop-specs/1.7/back-office/orders/orders/view-page.html#merchandise-return-has-to-be-enabled-if-the-merchant-wants-to-use-the-standard-refund-partial-refund-and-return-product-feature)
+For a full specification of how these features work, you can read [the functional specifications](https://build.prestashop-project.org/prestashop-specs/1.7/back-office/orders/orders/view-page.html#merchandise-return-has-to-be-enabled-if-the-merchant-wants-to-use-the-standard-refund-partial-refund-and-return-product-feature)
 {{% /notice %}}
 
 ## Order history and corresponding cancellation types

--- a/development/uikit.md
+++ b/development/uikit.md
@@ -5,7 +5,7 @@ weight: 70
 
 # What's the PrestaShop UIKit?
 
-The UIKit is a project extending Bootstrap 4 in order to provide some components with PrestaShop's colors. You can see every component on [this page](https://build.prestashop.com/prestashop-ui-kit/).
+The UIKit is a project extending Bootstrap 4 in order to provide some components with PrestaShop's colors. You can see every component on [this page](https://build.prestashop-project.org/prestashop-ui-kit/).
 
 ## How do we use the UIKit?
 

--- a/modules/introduction.md
+++ b/modules/introduction.md
@@ -39,7 +39,7 @@ Modules can:
 
 PrestaShop 1.7 was built so that modules that were written for PS 1.6 can work almost as-is — save for minor changes and a cosmetic update, the template files being in need of adapting to the 1.7 default theme.
 
-The major module development changes in PrestaShop 1.7 are explained in details [in this Build article](https://build.prestashop.com/news/module-development-changes-in-17/), and are integrated into this updated documentation. If you already know how to create a module that works with PS 1.6, we strongly advise you to read that article from top to bottom in order to get up to speed with 1.7 development.
+The major module development changes in PrestaShop 1.7 are explained in details [in this Build article](https://build.prestashop-project.org/news/module-development-changes-in-17/), and are integrated into this updated documentation. If you already know how to create a module that works with PS 1.6, we strongly advise you to read that article from top to bottom in order to get up to speed with 1.7 development.
 
 Some native modules have had their names changed in PrestaShop 1.7. [See the full list here]({{< ref "/8/development/native-modules/_index.md#module-name-changes-since-16" >}}).
 

--- a/project/release/minor-release-lifecycle.md
+++ b/project/release/minor-release-lifecycle.md
@@ -98,4 +98,4 @@ The global duration for all the process is about 6 months. This is why we expect
 
 
 _(This article was originally published on our blog: [PrestaShop 1.7 Minor Release Lifecycle
-](https://build.prestashop.com/news/ps17-patch-release-lifecycle/))_
+](https://build.prestashop-project.org/news/ps17-patch-release-lifecycle/))_

--- a/project/release/minor-release-lifecycle.md
+++ b/project/release/minor-release-lifecycle.md
@@ -98,4 +98,4 @@ The global duration for all the process is about 6 months. This is why we expect
 
 
 _(This article was originally published on our blog: [PrestaShop 1.7 Minor Release Lifecycle
-](https://build.prestashop-project.org/news/ps17-patch-release-lifecycle/))_
+](https://build.prestashop-project.org/news/ps17-minor-release-lifecycle/))_

--- a/project/release/patch-release-lifecycle.md
+++ b/project/release/patch-release-lifecycle.md
@@ -50,4 +50,4 @@ If the campaign reports that no bugs are found, the new patch release is validat
 
 
 _(This article was originally published on our blog: [PrestaShop 1.7 Patch Release Lifecycle
-](https://build.prestashop-project.org/news/ps17-minor-release-lifecycle/))_
+](https://build.prestashop-project.org/news/ps17-patch-release-lifecycle/))_

--- a/project/release/patch-release-lifecycle.md
+++ b/project/release/patch-release-lifecycle.md
@@ -50,4 +50,4 @@ If the campaign reports that no bugs are found, the new patch release is validat
 
 
 _(This article was originally published on our blog: [PrestaShop 1.7 Patch Release Lifecycle
-](https://build.prestashop.com/news/ps17-minor-release-lifecycle/))_
+](https://build.prestashop-project.org/news/ps17-minor-release-lifecycle/))_

--- a/themes/getting-started/setting-up-your-local-environment.md
+++ b/themes/getting-started/setting-up-your-local-environment.md
@@ -36,7 +36,7 @@ git checkout 8.0
 Also we would warn you to test your final result with a zip release, just for safety (since vendor version might be slightly different).
 
 {{% notice note %}}
-If you haven’t done it yet, we strongly recommend you to read our article [Set Up Your Git For Contributing](https://build.prestashop.com/howtos/misc/set-up-your-git-for-contributing/)
+If you haven’t done it yet, we strongly recommend you to read our article [Set Up Your Git For Contributing](https://build.prestashop-project.org/howtos/misc/set-up-your-git-for-contributing/)
 {{% /notice %}}
 
 ## Building your .gitignore file
@@ -58,7 +58,7 @@ Generally, you shouldn’t version the following types of files:
 We suggest that you build your own using https://gitignore.io.
 
 {{% notice note %}}
-If you are building a full project for a client, you can read our article on [building a gitignore for PrestaShop](https://build.prestashop.com/howtos/misc/prestashop-perfect-gitignore/).
+If you are building a full project for a client, you can read our article on [building a gitignore for PrestaShop](https://build.prestashop-project.org/howtos/misc/prestashop-perfect-gitignore/).
 {{% /notice %}}
 
 ## Create your theme from the Classic Theme


### PR DESCRIPTION
All urls have been tested, and are working

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Change urls from build.prestashop.com to build.prestashop-project.org

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
