### PR TITLE
Does not use deprecated/alias hook name

### DIFF
--- a/modules/carrier/_index.md
+++ b/modules/carrier/_index.md
@@ -47,12 +47,12 @@ Note about deletion:
 
 ## Controlling the change of the carrier's ID
 
-To control the change of the carrier's ID (id_carrier), the module must use the `updateCarrier` hook.
+To control the change of the carrier's ID (id_carrier), the module must use the `actionCarrierUpdate` hook.
 
 For instance:
 
 ```php
-public function hookUpdateCarrier($params)
+public function hookActionCarrierUpdate($params)
 {
     $id_carrier_old = (int) $params['id_carrier'];
     $id_carrier_new = (int) $params['carrier']->id;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Used hook is an alias. Use the good one.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
