### PR TITLE
displayHeader hook only affect Front Office pages

### DIFF
--- a/modules/concepts/hooks/list-of-hooks.md
+++ b/modules/concepts/hooks/list-of-hooks.md
@@ -2145,7 +2145,7 @@ displayFooterProduct
     
 displayHeader
 : 
-    Added in the header of every page
+    Added in the header of every Front Office page
 
     Located in: /classes/controller/FrontController.php
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Maybe we need to note _use displayBackOfficeHeader for Back Office pages_  somewhere in the docs
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
