### PR TITLE
Add example flag on ActionValidateOrder

### DIFF
--- a/modules/concepts/hooks/list-of-hooks/actionValidateOrder.md
+++ b/modules/concepts/hooks/list-of-hooks/actionValidateOrder.md
@@ -12,6 +12,7 @@ hookAliases:
  - newOrder
 aliases:
  - /8/modules/sample-modules/example-hooks/actionValidateOrder
+hasExample: true
 ---
 
 # Hook actionValidateOrder


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Added the hasExample flag on ActionValidateOrder

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
