### PR TITLE
Fix the path to the translations folder

### DIFF
--- a/basics/installation/localhost.md
+++ b/basics/installation/localhost.md
@@ -176,7 +176,6 @@ PrestaShop needs recursive write permissions on several directories:
 - ./admin-dev/autoupgrade
 - ./app/config
 - ./app/logs
-- ./app/Resources/translations
 - ./cache
 - ./config
 - ./download
@@ -193,7 +192,7 @@ PrestaShop needs recursive write permissions on several directories:
 You can set up the appropriate permissions using this command:
 
 ```bash
-$ chmod -R +w admin-dev/autoupgrade app/config app/logs app/Resources/translations cache config download img log mails modules override themes translations upload var
+$ chmod -R +w admin-dev/autoupgrade app/config app/logs cache config download img log mails modules override themes translations upload var
 ```
 
 If you do not have some of the folders above, please create them before changing permissions. For example:

--- a/contribute/contribute-pull-requests/contribute_using_localhost.md
+++ b/contribute/contribute-pull-requests/contribute_using_localhost.md
@@ -96,7 +96,6 @@ PrestaShop needs recursive write permissions on several directories:
 
 - /admin-dev/autoupgrade/
 - /app/logs
-- /app/Resources/translations
 - /cache
 - /config/themes
 - /download

--- a/development/internationalization/translation/introduction.md
+++ b/development/internationalization/translation/introduction.md
@@ -43,10 +43,10 @@ PrestaShop uses Symfony's [Translator Component](https://symfony.com/doc/4.4/tra
 This component is initialized for the configured language by loading five Catalogue Resources:
 
 * **Customized translations database** - Located in the `ps_translations` table.
-* **Active theme** – XLF files in `themes/<themename>/translations`.
-* **Core** – XLF files in `app/Resources/translations`.
-* **Active modules** – XLF files in `modules/<modulename>/translations`.
-* **Active modules (legacy)** – PHP files in `modules/<modulename>/translations`.
+* **Active theme** – XLF files in `./themes/<themename>/translations`.
+* **Core** – XLF files in `./translations`.
+* **Active modules** – XLF files in `./modules/<modulename>/translations`.
+* **Active modules (legacy)** – PHP files in `./modules/<modulename>/translations`.
 
 {{% notice tip %}}
 **The catalogue resources above are listed by precedence.** 

--- a/development/internationalization/translation/translation-tips.md
+++ b/development/internationalization/translation/translation-tips.md
@@ -9,7 +9,7 @@ weight: 50
 
 Wordings for the Core and Native modules can only be translated if they are declared in PrestaShop's default translation catalogue. Therefore, whenever a new wording is added to the core or to a native module, it must be added to the default catalogue as well. 
 
-Normally you would have to manually add each wording the appropriate default catalogue files (located in the `app/Resources/translations/default` folder). Thankfully, this task has been automated by the Core team!
+Normally you would have to manually add each wording the appropriate default catalogue files (located in the `./translations/default` folder). Thankfully, this task has been automated by the Core team!
  
 Before every minor release, the whole source code for PrestaShop and Native Modules is analyzed using [TranslationToolsBundle](https://github.com/PrestaShop/TranslationToolsBundle), and all newly discovered wordings are automatically added to the default catalogue.
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | The path to the translations folder changed from `app/Resources/translations/` to `translations/` in v8. This PR updates articles referencing the old folder.
| Fixed ticket? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
