### PR TITLE
Update link to "Get involved" page

### DIFF
--- a/contribute/_index.md
+++ b/contribute/_index.md
@@ -11,6 +11,6 @@ chapter: true
 
 PrestaShop is a community project, made by hundreds of people collaborating around the world. You can get involved too!
 
-- [How to get involved in the project](https://prestashop-project.org/get-involved/)
+- [How to get involved in the project](https://www.prestashop-project.org/get-involved/)
 
 {{% children %}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | The current first link on https://devdocs.prestashop-project.org/8/contribute/ seems to be redirecting to a `/get-involved` page on the PrestaShop Project but we end on the home page. After finding a similar page on a link with a subdomain, I guess the original one just needed to be fixed.
| Fixed ticket? | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
