### PR TITLE
Template  display.tpl must extend page.tpl

### DIFF
--- a/modules/creation/displaying-content-in-front-office.md
+++ b/modules/creation/displaying-content-in-front-office.md
@@ -393,7 +393,7 @@ in our TPL file.
 
 - *mymodule.tpl*
 
-```
+```smarty
 {extends file='page.tpl'}
 {block name='page_content'}
     {$my_module_message}

--- a/modules/creation/displaying-content-in-front-office.md
+++ b/modules/creation/displaying-content-in-front-office.md
@@ -308,7 +308,7 @@ class mymoduledisplayModuleFrontController extends ModuleFrontController
 
 - *display.tpl*
 
-```
+```smarty
 {extends file='page.tpl'}
 {block name='page_content'}
    Welcome to my shop!

--- a/modules/creation/displaying-content-in-front-office.md
+++ b/modules/creation/displaying-content-in-front-office.md
@@ -309,7 +309,10 @@ class mymoduledisplayModuleFrontController extends ModuleFrontController
 - *display.tpl*
 
 ```
-Welcome to my shop!
+{extends file='page.tpl'}
+{block name='page_content'}
+   Welcome to my shop!
+{/block}
 ```
 
 Let's explore `display.php`, our first PrestaShop front-end controller,
@@ -391,7 +394,10 @@ in our TPL file.
 - *mymodule.tpl*
 
 ```
-{$my_module_message}
+{extends file='page.tpl'}
+{block name='page_content'}
+    {$my_module_message}
+{/block}
 ```
 
 PrestaShop adds its own set of variables. For instance,


### PR DESCRIPTION
Currently the template displays raw non-nested content.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
