### PR TITLE
Remove reference to new product page on 8.0, because documented in 8.1 changes

### DIFF
--- a/modules/core-updates/8.0.md
+++ b/modules/core-updates/8.0.md
@@ -49,10 +49,6 @@ Symfony has been [upgraded to 4.4](https://github.com/PrestaShop/PrestaShop/pull
 * The annotation `@AdminSecurity is_granted()` should not take an array, use explicit `&&` or `||` when checking multiple rights
 * Form type extensions should stop implementing `public function getExtendedType()` and implement `public static function getExtendedTypes(): iterable` instead ([read more](https://symfony.com/blog/new-in-symfony-4-2-improved-form-type-extensions)).
 
-### New product page
-
-[To be completed]
-
 ### Themes
 
 Themes using jQuery UI tooltips might need to be updated to use bootstrap's tooltips ([read more](https://github.com/PrestaShop/PrestaShop/pull/25818));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x

Documented here : https://devdocs.prestashop-project.org/8/modules/core-updates/8.1/
https://devdocs.prestashop-project.org/8/modules/sample-modules/extend-product-page/

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
