### PR TITLE
Update tutorial.md

### DIFF
--- a/modules/creation/tutorial.md
+++ b/modules/creation/tutorial.md
@@ -45,7 +45,7 @@ The main file must contain the module's main class.
 If you need to add more classes later, we suggest writing one single class per file.
 {{% /notice %}}
 
-That main class must bear the same name as the module and its folder, in [CamelCase](https://en.wikipedia.org/wiki/CamelCase). In our example: `MyModule`. Furthermore, that class must extend the `Module` class, in order to inherit all its methods and attributes.
+That main class must bear the same name as the module and its folder, in [PascalCase](https://www.freecodecamp.org/news/snake-case-vs-camel-case-vs-pascal-case-vs-kebab-case-whats-the-difference/#pascal-case). In our example: `MyModule`. Furthermore, that class must extend the `Module` class, in order to inherit all its methods and attributes.
 
 ```php
 <?php


### PR DESCRIPTION
I thing there's been a confusion between camelCase and PascalCase. CamelCase is a convention used in programming and computer-related fields to write compound words or phrases where each word within the compound starts with a capital letter, except for the first word. In PascalCase, also known as UpperCamelCase, each word within a compound starts with an uppercase letter, including the first word. "MyModule" is in PascalCase, in your doc, it's defined as camelCase.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
