### PR TITLE
Update commands.md to fix base command name in the DevDocs

### DIFF
--- a/modules/concepts/commands.md
+++ b/modules/concepts/commands.md
@@ -35,7 +35,7 @@ First you need to setup your composer file, you will find more info about it in 
 
 ### Creation of the command
 
-At this moment, the only requirement is that you PHP file needs to be a class that extends `Symfony\Component\Console\Command`. Let's create ExportCommand file:
+At this moment, the only requirement is that you PHP file needs to be a class that extends `Symfony\Component\Console\Command\Command`. Let's create ExportCommand file:
 
 ```php
 <?php


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x
| Description?  |Fixed the name from the Symfony Command class from `Symfony\Component\Console\Command` to `Symfony\Component\Console\Command\Command` in the DevDocs
| Fixed ticket? | None

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
