### PR TITLE
Wrong code in tutorial page

### DIFF
--- a/modules/creation/adding-configuration-page-modern.md
+++ b/modules/creation/adding-configuration-page-modern.md
@@ -123,7 +123,7 @@ services:
 
   # Demo configuration text form
   prestashop.module.demosymfonyformsimple.form.type.demo_configuration_text:
-    class: 'PrestaShop\Module\DemoSymfonyFormSimple\Form\DemoConfigurationTextType'
+    class: 'PrestaShop\Module\DemoSymfonyFormSimple\Form\DemoConfigurationFormType'
     parent: 'form.type.translatable.aware'
     public: true
     tags:
@@ -286,7 +286,7 @@ Simply register it in `config/services.yml`:
       - '@form.factory'
       - '@prestashop.core.hook.dispatcher'
       - '@prestashop.module.demosymfonyformsimple.form.demo_configuration_text_form_data_provider'
-      - 'PrestaShop\Module\DemoSymfonyFormSimple\Form\DemoConfigurationTextType'
+      - 'PrestaShop\Module\DemoSymfonyFormSimple\Form\DemoConfigurationFormType'
       - 'DemoConfiguration'
 ```
 

--- a/modules/creation/adding-configuration-page-modern.md
+++ b/modules/creation/adding-configuration-page-modern.md
@@ -376,7 +376,7 @@ You can read more about controllers in [controller & routing section]({{<relref 
 Create a `routes.yml` file in `config/`. 
 
 ```yml
-demo_configuration_form:
+demo_configuration_form_simple:
   path: /demosymfonyformsimple/configuration
   methods: [GET, POST]
   defaults:

--- a/modules/creation/adding-configuration-page-modern.md
+++ b/modules/creation/adding-configuration-page-modern.md
@@ -130,7 +130,7 @@ services:
       - { name: form.type }
 ```
 
-This `services.yml` file is registering your `PrestaShop\Module\DemoSymfonyFormSimple\Form\DemoConfigurationTextType` class as `prestashop.module.demosymfonyformsimple.form.type.demo_configuration_text`. It also add a tag `name: form.type`, and declares it as `public`. 
+This `services.yml` file is registering your `PrestaShop\Module\DemoSymfonyFormSimple\Form\DemoConfigurationFormType` class as `prestashop.module.demosymfonyformsimple.form.type.demo_configuration_text`. It also add a tag `name: form.type`, and declares it as `public`. 
 
 {{% notice note %}}
 You can read more about services in the [official Symfony official documentation](https://symfony.com/doc/4.4/service_container.html)
@@ -275,7 +275,7 @@ In `config/services.yml`, register your newly created `DemoConfigurationTextForm
 
 For this form handler, we don't need to create a new class, we can use PrestaShop native's one.
 
-By receiving an instance of `DemoConfigurationTextFormDataProvider` and `DemoConfigurationTextType`, the PrestaShop native Form Handler is able to process the data it receives.
+By receiving an instance of `DemoConfigurationTextFormDataProvider` and `DemoConfigurationFormType`, the PrestaShop native Form Handler is able to process the data it receives.
 
 Simply register it in `config/services.yml`: 
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  8.x
| Description?  | Attempt to fix the code in "Modern configuration page" in prestashop documentation. I was following this tutorial and ran accross those errors. The changes are from https://github.com/PrestaShop/example-modules/blob/master/demosymfonyformsimple
| Fixed ticket? | No I don't think so.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
