### PR TITLE
Allow .well-known directory (pki validation / letsencrypt)

### DIFF
--- a/basics/installation/advanced/nginx.md
+++ b/basics/installation/advanced/nginx.md
@@ -90,11 +90,6 @@ server {
       deny all;
     }
 
-    # files in .well-known should be served as plain text.
-    location ~* ^/\.well-known\/ {
-        default_type text/plain;
-    }
-
     # Source code directories.
     location ~ ^/(app|bin|cache|classes|config|controllers|docs|localization|override|src|tests|tools|translations|var|vendor)/ {
         deny all;

--- a/basics/installation/advanced/nginx.md
+++ b/basics/installation/advanced/nginx.md
@@ -85,9 +85,9 @@ server {
         }
     }
 
-    # .htaccess, .DS_Store, .htpasswd, etc., but keep .well-known available
-    location ~* /\.(?!well-known\/) {
-      deny all;
+    # .htaccess, .DS_Store, .htpasswd, etc.
+    location ~ /\. {
+        deny all;
     }
 
     # Source code directories.

--- a/basics/installation/advanced/nginx.md
+++ b/basics/installation/advanced/nginx.md
@@ -85,9 +85,9 @@ server {
         }
     }
 
-    # .htaccess, .DS_Store, .htpasswd, etc.
-    location ~ /\. {
-        deny all;
+    # .htaccess, .DS_Store, .htpasswd, etc., but keep .well-known available
+    location ~* /\.(?!well-known\/) {
+      deny all;
     }
 
     # Source code directories.

--- a/basics/installation/advanced/nginx.md
+++ b/basics/installation/advanced/nginx.md
@@ -90,6 +90,11 @@ server {
       deny all;
     }
 
+    # files in .well-known should be served as plain text.
+    location ~* ^/\.well-known\/ {
+        default_type text/plain;
+    }
+
     # Source code directories.
     location ~ ^/(app|bin|cache|classes|config|controllers|docs|localization|override|src|tests|tools|translations|var|vendor)/ {
         deny all;

--- a/scale/webservers/nginx.md
+++ b/scale/webservers/nginx.md
@@ -107,7 +107,7 @@ server {
 }
 ```
 
-### Allow usage of `.well-known` directory (letsencrypt/pki validation, apple pay)
+### Allow usage of `.well-known` directory (Let's Encrypt / PKI validation, Apple Pay)
 
 The `.well-known` directory is a resource documented in [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) and used by [many services](https://en.m.wikipedia.org/wiki/Well-known_URI).
 If you need an external access to the `.well-known` directory, you can update you nginx configuration to use:

--- a/scale/webservers/nginx.md
+++ b/scale/webservers/nginx.md
@@ -106,3 +106,20 @@ server {
     ...
 }
 ```
+
+### Allow usage of `.well-known` directory (letsencrypt/pki validation, apple pay)
+
+The `.well-known` directory is a resource documented in [RFC 8615](https://datatracker.ietf.org/doc/html/rfc8615) and used by [many services](https://en.m.wikipedia.org/wiki/Well-known_URI).
+If you need an external access to the `.well-known` directory, you can update you nginx configuration to use:
+
+```nginx
+# .htaccess, .DS_Store, .htpasswd, etc., but keep .well-known available
+ location ~* /\.(?!well-known\/) {
+   deny all;
+ }
+
+# files in .well-known should be served as plain text.
+location ~* ^/\.well-known\/ {
+    default_type text/plain;
+}
+```

--- a/scale/webservers/nginx.md
+++ b/scale/webservers/nginx.md
@@ -114,9 +114,9 @@ If you need an external access to the `.well-known` directory, you can update yo
 
 ```nginx
 # .htaccess, .DS_Store, .htpasswd, etc., but keep .well-known available
- location ~* /\.(?!well-known\/) {
-   deny all;
- }
+location ~* /\.(?!well-known\/) {
+    deny all;
+}
 
 # files in .well-known should be served as plain text.
 location ~* ^/\.well-known\/ {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | Fix nginx example configuration to allow .well-known directory usage, which is used for pki validation or acme / letsencrypt
| Fixed ticket? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
