### PR TITLE
docs: fix array key typo

### DIFF
--- a/development/components/database/objectmodel.md
+++ b/development/components/database/objectmodel.md
@@ -409,12 +409,12 @@ classDiagram
 
 #### Enable multi language + multi shop for your entity
 
-To do so, you must declare the `multishop_lang` setting of your model definition to `true`:
+To do so, you must declare the `multilang_shop` setting of your model definition to `true`:
 
 ```php
 public static $definition = [
     ...
-    'multishop_lang' => true,
+    'multilang_shop' => true,
     ...
 ```
 
@@ -432,7 +432,7 @@ And then, you must declare which fields are available for translations:
 )
 ```
 
-#### Loading or saving a multishop_lang object
+#### Loading or saving a multilang_shop object
 
 While languages are [accessible with accessors]({{< ref "#multiple-language-accessors" >}}), if you need to programmatically retrieve an ObjectModel related to a particular shop (not the selected / current shop from Context), you need to change the method used to load an object:
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | I've encountered a typo that make me loss some minutes to investigate, so I have created this PR to next developer that needs to create a new multilang_shop ObjectModel :) 
| Fixed ticket? | nope

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

This is Category class that have the right property where I searched for:

![immagine](https://github.com/PrestaShop/docs/assets/14024456/a724a367-f348-4949-ba12-ca084864a4b6)
