### PR TITLE
Replace git checkout example with version 8.0.0

### DIFF
--- a/themes/getting-started/setting-up-your-local-environment.md
+++ b/themes/getting-started/setting-up-your-local-environment.md
@@ -30,7 +30,7 @@ Open a command line on your (empty) working directory, then:
 
 Using git you can choose your PrestaShop version:
 ```bash
-git checkout 8.0.0
+git checkout 8.1.x
 ```
 
 Also we would warn you to test your final result with a zip release, just for safety (since vendor version might be slightly different).

--- a/themes/getting-started/setting-up-your-local-environment.md
+++ b/themes/getting-started/setting-up-your-local-environment.md
@@ -30,7 +30,7 @@ Open a command line on your (empty) working directory, then:
 
 Using git you can choose your PrestaShop version:
 ```bash
-git checkout 8.0
+git checkout 8.0.0
 ```
 
 Also we would warn you to test your final result with a zip release, just for safety (since vendor version might be slightly different).


### PR DESCRIPTION
The version 8.0 doesn't exist on tags available (doing `git tag -l`, for example, do not show version 8.0). The closest version (compared with the current version) is the version 8.0.0

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
