### PR TITLE
Add explanation about PS_VERSION_DB mismatch

### DIFF
--- a/faq/upgrade.md
+++ b/faq/upgrade.md
@@ -32,3 +32,13 @@ If during upgrade process, it fails with the error message:
 This error message indicates something went wrong on server side.
 
 In order to find out what exactly went wrong, you need to check the upgrade process logs that are located into the folder `{Prestashop_Folder}/{Admin_folder}/autoupgrade/tmp/`
+
+## The version of PrestaShop does not match the one stored in database
+
+**Q:** Upgrade cannot start because the error "The version of PrestaShop stored in database does not match the running code. Your database structure may not be up-to-date and/or the value of PS_VERSION_DB needs to be updated in the configuration table." is displayed.
+
+**A:** In PrestaShop, `PS_VERSION_DB` is a constant that holds the current version number of your PrestaShop database schema. The main purpose of `PS_VERSION_DB` is to keep track of the database schema's version history. When you upgrade a shop, the database schema is modified to match the structure of the new version (e.g. add or remove tables, columns, or relationships). 
+
+Before upgrading PrestaShop, the upgrade module relies on this constant to ensure that the current version matches the database schema. If the values don't match, it would be a sign of potential issues with the database structure or data which could lead to unforeseen consequences during the upgrade process.
+
+To resolve this issue, run the database upgrade step as explained in [the upgrade page]({{< ref "/8/basics/keeping-up-to-date/upgrade#database-upgrade" >}}).


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | A check is added to the upgrade module about the PS_VERSION_DB, where we require merchants to have an up to date database before starting another upgrade on top of it. Not doing so leads to duplicate SQL requests to be executed, or some of them missing.
| Fixed ticket? | Partially fixes https://github.com/PrestaShop/PrestaShop/issues/33856 with https://github.com/PrestaShop/autoupgrade/pull/696
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
