### PR TITLE
Upgraded NodeJS version

### DIFF
--- a/basics/installation/_index.md
+++ b/basics/installation/_index.md
@@ -205,7 +205,7 @@ make composer
 ##### JavaScript and CSS dependencies
 
 PrestaShop uses `NPM` to manage dependencies and [`Webpack`][webpack] to compile them into static assets. 
-You only need `NodeJS 14.x` (version `16.x` is recommended, [you can get it here][nodejs]), and NPM will take care of it all.
+You only need `NodeJS 16.x` ([you can get it here][nodejs]), and NPM will take care of it all.
 
 ```bash
 cd /path/to/prestashop

--- a/basics/installation/system-requirements.md
+++ b/basics/installation/system-requirements.md
@@ -118,7 +118,7 @@ PrestaShop uses `Composer` to manage its packages. Install it [here][composer].
 ### NodeJS
 
 PrestaShop uses `NPM` to manage frontend dependencies and [`Webpack`][webpack] to compile them into static assets. 
-You only need `NodeJS 14.x` (version `16.x` is recommended, [you can get it here][nodejs]), and `NPM` will take care of it all.
+You only need `NodeJS 16.x` ([you can get it here][nodejs]), and `NPM` will take care of it all.
 
 #### NVM
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -15,7 +15,7 @@ Here is a list of compatibility:
 
 | PrestaShop Versions | NodeJS Versions | NPM Versions |
 |---------------------|-----------------|--------------|
-| 8.x                 | 16.x            | 8.x          |
+| 9.x                 | 16.x            | 8.x          |
 
 If you can not manage to compile assets, you may be using an older version of PrestaShop. We strongly recommend you to install a package such as ['n'](https://www.npmjs.com/package/n?activeTab=versions) or [nvm](https://github.com/nvm-sh/nvm) to try with an older version of NodeJS.
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -13,9 +13,9 @@ We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop is using
 
 Here is a list of compatibility: 
 
-| PrestaShop Versions | NodeJS Versions |   NPM Versions  |
-|---------------------|-----------------|-----------------|
-| 8.x                 | 14.x or 16.x    | 7.x or 8.x      |
+| PrestaShop Versions | NodeJS Versions | NPM Versions |
+|---------------------|-----------------|--------------|
+| 8.x                 | 16.x            | 8.x          |
 
 If you can not manage to compile assets, you may be using an older version of PrestaShop. We strongly recommend you to install a package such as ['n'](https://www.npmjs.com/package/n?activeTab=versions) or [nvm](https://github.com/nvm-sh/nvm) to try with an older version of NodeJS.
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 9.x
| Description?  | Upgraded NodeJS version


Hummingbird theme will be added to PrestaShop 9.x release. 
This theme requires NodeJS > 16. 
Classic theme requires NodeJS > 14. 

So we need to update our requirements. 