### PR TITLE
Update misleading create-custom-column-type.md

### DIFF
--- a/development/components/grid/tutorials/create-custom-column-type.md
+++ b/development/components/grid/tutorials/create-custom-column-type.md
@@ -28,7 +28,7 @@ final class HtmlColumn extends AbstractColumn
      */
     public function getType()
     {
-        return 'html';
+        return 'customhtml';
     }
 
     /**
@@ -75,7 +75,7 @@ Then inside the getColumns function among other columns, you are welcome to use 
 ## Step 3. Define the respective .html.twig
 Let's assume that we need to make an html column to fire some js script. Create the following file:
 
-```/modules/your_cool_module/views/PrestaShop/Admin/Common/Grid/Columns/Content/html.html.twig```
+```/modules/your_cool_module/views/PrestaShop/Admin/Common/Grid/Columns/Content/customhtml.html.twig```
 
 ```<a href="#">{{ record[column.options.field] }}</a>```
 


### PR DESCRIPTION
Change column type name and twig template name. Using **html.html.twig** overrides this template on **all pages** so with "html" this tutorial is misleading.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | I followed this tutorial and had very unexpected result on PS 8.1.7. This tutorial overrides template instead of creating new custom column.
| Fixed ticket? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
