### PR TITLE
Recommend PHP 8.3 by default

### DIFF
--- a/basics/installation/system-requirements.md
+++ b/basics/installation/system-requirements.md
@@ -12,7 +12,7 @@ PrestaShop needs the following server configuration in order to run:
 | Requirement | Configuration 
 | ---------------- | ------------------
 | **Web server** | Apache Web Server 2.4 or any later version. (Although compatible, Apache Web Server 2.2 is not recommended since it [reached its EOL in 2018](https://httpd.apache.org/)).
-| **PHP** | **We recommend PHP 8.1**. See the compatibility chart below for more details.
+| **PHP** | **We recommend PHP 8.3**. See the compatibility chart below for more details.
 | **MySQL** | 5.6 minimum, **a recent version is recommended**.
 | **Server RAM** | **The more the merrier**. We recommend setting the memory allocation per script (`memory_limit`) to a minimum of `256M`.
 
@@ -59,12 +59,12 @@ You'll get a web page detailing requirements and recommendations, and how your s
   <tr>
     <td>9.0</td>
     <td class="support-no"><span class="sr-only">No</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
+    <td class="support-yes"><span class="sr-only">Yes</span></td>
     <td class="support-yes">
       <i class="fa fa-check" aria-hidden="true" title="Recommended version"></i>
       <span class="sr-only">Recommended version</span>
     </td>
-    <td class="support-yes"><span class="sr-only">Yes</span></td>
-    <td class="support-yes"><span class="sr-only">Yes</span></td>
     <td class="support-no"><span class="sr-only">No</span></td>
   </tr>
 </tbody>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 9.x
| Description?  | PHP 8.1 will go outdated in few months, so we should recommend PHP 8.3 by default for PrestaShop 9. All modules must be 100% compatible with PHP 8.3, if they want to claim compatibility with Prestashop 9. There is no reason NOT to recommend the latest version of PHP.
| Fixed ticket? | 

