### PR TITLE
fix to use correct field value

### DIFF
--- a/modules/creation/displaying-content-in-front-office.md
+++ b/modules/creation/displaying-content-in-front-office.md
@@ -52,7 +52,7 @@ Add the following to your mymodule.php file:
     public function hookDisplayLeftColumn($params)
     {
         $this->context->smarty->assign([
-            'my_module_name' => Configuration::get('MYMODULE_NAME'),
+            'my_module_name' => Configuration::get('MYMODULE_CONFIG'),
             'my_module_link' => $this->context->link->getModuleLink('mymodule', 'display')
         ]);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | The docs refers to MYMODULE_NAME to get the input value. However earlier in the document it refers to as MYMODULE_CONFIG. Suddenly the name changes from MYMODULE_CONFIG to MYMODULE_NAME so the value is not displayed. Therefore this name fix should make it work properly.
| Fixed ticket? |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
