### PR TITLE
Fix Typo in phpMyAdmin example

### DIFF
--- a/basics/installation/environments/docker.md
+++ b/basics/installation/environments/docker.md
@@ -344,6 +344,8 @@ services:
         PMA_HOST: some-mysql
         PMA_PORT: 3306
         PMA_ARBITRARY: 1
+        PMA_USER: root
+        PMA_PASSWORD: admin
       restart: unless-stopped
       ports:
         - 8081:80

--- a/basics/installation/environments/docker.md
+++ b/basics/installation/environments/docker.md
@@ -347,6 +347,8 @@ services:
       restart: unless-stopped
       ports:
         - 8081:80
+      networks:
+        - prestashop_network
 ```
 
 And access `http://localhost:8081` to access `phpMyAdmin`.

--- a/basics/installation/environments/docker.md
+++ b/basics/installation/environments/docker.md
@@ -339,7 +339,7 @@ services:
       image: phpmyadmin/phpmyadmin
       container_name: phpmyadmin
       links:
-        - some-mysql
+        - mysql
       environment:
         PMA_HOST: some-mysql
         PMA_PORT: 3306


### PR DESCRIPTION
the service is mysql not some-mysql

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  8.x 
| Description?  | The docker compose example for adding phpMyAdmin has a typo in its links definition, the example fails as its looking for the service name instead of the container name, additionally ensure the the container can reach the mysql service by adding it to the shared private network.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
