### PR TITLE
docs: fix docker image tag displayed

### DIFF
--- a/basics/installation/environments/docker.md
+++ b/basics/installation/environments/docker.md
@@ -437,7 +437,7 @@ All our images and tags are available on [Docker Hub](https://hub.docker.com/r/p
 You can use a specific PrestaShop version by changing the image tag: 
 
 - Use latest image: `prestashop/prestashop:latest`
-- Use 1.7: `prestashop/prestashop:latest`
+- Use 1.7: `prestashop/prestashop:1.7`
 - Use 1.7.8: `prestashop/prestashop:1.7.8`
 
 ### Use a specific PHP version


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | -
| Description?  | The docker image tag displayed should be "1.7" instead of "latest".
| Fixed ticket? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
