### PR TITLE
Allow .well-known folder on Nginx

### DIFF
--- a/basics/installation/advanced/nginx.md
+++ b/basics/installation/advanced/nginx.md
@@ -103,7 +103,7 @@ server {
 
 
     # .htaccess, .DS_Store, .htpasswd, etc.
-    location ~ /\. {
+    location ~ /\.(?!well-known) {
         deny all;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 8.x
| Description?  | See below
| Fixed ticket? | Fixes #1911

Updated the Nginx configuration to explicitly allow access to the `.well-known` directory while maintaining the restriction for other hidden files and directories (e.g., `.htaccess`, `.htpasswd`).

The `.well-known` directory is commonly used for domain verification and other standards-compliant purposes (e.g., Apple Pay’s `apple-developer-merchantid-domain-association` file). This change ensures that legitimate requests to `.well-known` resources are served while keeping other hidden files secure.

Steps to Verify:
1. Place a test file (e.g., `.well-known/test-file`) in the web root.
2. Verify that the file is accessible at `http://yourdomain.com/.well-known/test-file`.
3. Confirm that other hidden files (e.g., `.htaccess`) remain inaccessible.

Changes Made:
- Modified the existing `location ~ /\.` block to ensure `.well-known` is accessible.
- The updated configuration maintains the deny rule for all other hidden files and directories, preserving security.
