### PR TITLE
Update module-file-structure.md

### DIFF
--- a/modules/creation/module-file-structure.md
+++ b/modules/creation/module-file-structure.md
@@ -145,7 +145,7 @@ A few details:
 
 ### `logo.png` file
 
-This icon file will be displayed in module listings if present. It needs to be a 32x32 pixel PNG file.
+This icon file will be displayed in module listings if present. It needs to be a PNG file. We recommend a size of 140 x 140 pixels.
 
 ### `mymodule.php` file (main file)
 


### PR DESCRIPTION
The logo doesn't have to be 32x32 pixels: most PrestaShop native module logos are 140x140 pixels. Also, rendering a 32x32 size is too pixelated in the back office because it's too stretched.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x / 9.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
