### PR TITLE
Update tutorial.md

### DIFF
--- a/modules/creation/tutorial.md
+++ b/modules/creation/tutorial.md
@@ -272,7 +272,7 @@ To put the finishing touch to this basic module, you should add an icon, which w
 The icon file must respect these requirements:
 
 - It must be placed on the module's main folder.
-- PNG format, 32 by 32 pixels in size.
+- PNG format.
 - Named `logo.png`.
 
 {{% notice tip %}}


### PR DESCRIPTION
The logo doesn't have to be 32x32 pixels: most PrestaShop native module logos are 140x140 pixels. Also, rendering a 32x32 size is too pixelated in the back office because it's too stretched.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x / 9.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
