### PR TITLE
Update actionFilterDeliveryOptionList.md

### DIFF
--- a/modules/concepts/hooks/list-of-hooks/actionFilterDeliveryOptionList.md
+++ b/modules/concepts/hooks/list-of-hooks/actionFilterDeliveryOptionList.md
@@ -61,7 +61,7 @@ class MyCarrierConditionDisablerModule extends Module
         return parent::install() && $this->registerHook('actionFilterDeliveryOptionList');
     }
 
-    public function hookActionCustomFilterDeliveryOptionList($params)
+    public function hookActionFilterDeliveryOptionList($params)
     {
         $deliveryOptionList = $params['delivery_option_list'];
         


### PR DESCRIPTION
On 8.x, the hook is not hookActionCustomFilterDeliveryOptionList, but hookActionFilterDeliveryOptionList (I try with `Custom`, it doesn't work)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x / 9.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
