### PR TITLE
Correct resource name for product_customization_field

### DIFF
--- a/webservice/resources/product_customization_fields.md
+++ b/webservice/resources/product_customization_fields.md
@@ -4,7 +4,7 @@ title: Product customization fields
 
 # Resources for Product customization fields
 
-### Customization_field
+### Product_customization_field
 
 |      Name      |    Format    | Required | Max size | Description |
 | :------------- | :----------- | :------: | -------: | :---------- |
@@ -20,7 +20,7 @@ title: Product customization fields
 
 ```xml
 <prestashop xmlns:xlink="http://www.w3.org/1999/xlink">
-  <customization_field>
+  <product_customization_field>
     <id><![CDATA[]]></id>
     <id_product><![CDATA[]]></id_product>
     <type><![CDATA[]]></type>
@@ -31,7 +31,7 @@ title: Product customization fields
       <language id="1"><![CDATA[]]></language>
       <language id="2"><![CDATA[]]></language>
     </name>
-  </customization_field>
+  </product_customization_field>
 </prestashop>
 ```
 


### PR DESCRIPTION
The resource was missing the `product_` prefix.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/8/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | Documentation for 1.7.x, but the problem is present also in the docs for the 8.x and 9.x.
| Description?  | The page reported the resource as `customization_field` instead of `product_customization_field`.
| Fixed ticket? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


