### PR TITLE
modules mail theme add layout change path of layout replace __DIR__ b…

### DIFF
--- a/modules/concepts/mail-templates/add-a-layout-from-module.md
+++ b/modules/concepts/mail-templates/add-a-layout-from-module.md
@@ -120,7 +120,7 @@ class MyEmailThemeModule extends Module
             // Add a layout to each theme (don't forget to specify the module name)
             $theme->getLayouts()->add(new Layout(
                 'custom_template',
-                __DIR__ . '/mails/layouts/custom_' . $theme->getName() . '_layout.html.twig',
+                '@Modules/' . $this->name . '/mails/layouts/custom_' . $theme->getName() . '_layout.html.twig',
                 '',
                 $this->name
             ));


### PR DESCRIPTION
…y Twig Path @Modules, to prevent error at the generation (template path is not found)

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  8.x / 9.x
| Description?  | In PrestaShop 8, when we want to add layout to a theme (modern or classic), in the doc the path to find layout start by __DIR__ however when PrestaShop want to generate the layout with Twig PrestaShop dont find the template path. To fix replace __DIR__ by @Modules
