### PR TITLE
v9: build are not available on GitHub

### DIFF
--- a/basics/installation/_index.md
+++ b/basics/installation/_index.md
@@ -163,6 +163,10 @@ PrestaShop comes in two "flavors":
 If you intend to work on PrestaShop itself, we suggest using Git to clone the source code of PrestaShop from the GitHub repository.
 {{% /notice %}}
 
+{{% notice warning %}}
+Starting with PrestaShop 9, releases versions are not build on GitHub and are not available on GitHub anymore. Read our [article](https://build.prestashop-project.org/news/2024/new-zip-distribution-channel/) on Build blog for more informations about it.
+{{% /notice %}}
+
 {{% callout %}}
 
 ##### Repository branches

--- a/basics/installation/_index.md
+++ b/basics/installation/_index.md
@@ -164,7 +164,7 @@ If you intend to work on PrestaShop itself, we suggest using Git to clone the so
 {{% /notice %}}
 
 {{% notice warning %}}
-Starting with PrestaShop 9, releases versions are not build on GitHub and are not available on GitHub anymore. Read our [article](https://build.prestashop-project.org/news/2024/new-zip-distribution-channel/) on Build blog for more informations about it.
+Starting with PrestaShop 9, releases versions are not built on GitHub and are not available on GitHub anymore. Read our [article](https://build.prestashop-project.org/news/2024/new-zip-distribution-channel/) on Build blog for more informations about it.
 {{% /notice %}}
 
 {{% callout %}}

--- a/basics/installation/_index.md
+++ b/basics/installation/_index.md
@@ -164,7 +164,7 @@ If you intend to work on PrestaShop itself, we suggest using Git to clone the so
 {{% /notice %}}
 
 {{% notice warning %}}
-Starting with PrestaShop 9, releases versions are not built on GitHub and are not available on GitHub anymore. Read our [article](https://build.prestashop-project.org/news/2024/new-zip-distribution-channel/) on Build blog for more informations about it.
+Starting with PrestaShop 9, release versions are no longer built or available on GitHub. For more information, read our [article](https://build.prestashop-project.org/news/2024/new-zip-distribution-channel/) on the Build blog.
 {{% /notice %}}
 
 {{% callout %}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 9.x
| Description?  | Build versions are not available on GitHub, since 9.x.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
