### PR TITLE
Update docker.md: Update Docker image to PrestaShop 1.7: use prestash…

### DIFF
--- a/basics/installation/environments/docker.md
+++ b/basics/installation/environments/docker.md
@@ -437,7 +437,7 @@ All our images and tags are available on [Docker Hub](https://hub.docker.com/r/p
 You can use a specific PrestaShop version by changing the image tag: 
 
 - Use latest image: `prestashop/prestashop:latest`
-- Use 1.7: `prestashop/prestashop:latest`
+- Use 1.7: `prestashop/prestashop:1.7`
 - Use 1.7.8: `prestashop/prestashop:1.7.8`
 
 ### Use a specific PHP version


### PR DESCRIPTION
…op/prestashop:1.7

Switched the Docker image from `prestashop/prestashop:latest` to `prestashop/prestashop:1.7` to ensure consistency with PrestaShop 1.7-based projects.

Could you please confirm which specific minor version (e.g., 1.7.8.10) is pulled when using the generic `1.7` tag? This would help us ensure long-term reproducibility and avoid unexpected upgrades.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.x / 8.x / 9.x
| Description?  | Please be specific when describing the PR. What did you add, why did you submit it?
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
