### PR TITLE
fix: mobile actions are not handled in v9

### DIFF
--- a/development/components/console/prestashop-module.md
+++ b/development/components/console/prestashop-module.md
@@ -8,7 +8,7 @@ title: prestashop:module
 
 * Path: `src/PrestaShopBundle/Command/ModuleCommand.php`
 * Arguments:
-  * `action`: Action to execute, must be one of: install, uninstall, enable, disable, enableMobile, disableMobile, reset, upgrade, configure, registerHook, unregisterHook
+  * `action`: Action to execute, must be one of: install, uninstall, enable, disable, reset, upgrade, configure, registerHook, unregisterHook
   * `module name`: Module on which the action will be executed
   * `file path`: YML file path for configuration __(optional)__
 * Options:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 9.x
| Description?  | Remove mobile actions not handled anymore.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
