### PR TITLE
Add documentation for thumbnails regenerate command

### DIFF
--- a/development/components/console/prestashop-thumbnails-regenerate.md
+++ b/development/components/console/prestashop-thumbnails-regenerate.md
@@ -1,0 +1,36 @@
+---
+title: prestashop:thumbnails:regenerate
+---
+
+# `prestashop:thumbnails:regenerate`
+
+## Informations
+
+* Path: `src/PrestaShopBundle/Command/RegenerateThumbnailsCommand.php`
+* Arguments:
+  * `image`: Image domain (e.g products, categories, manufacturers, ...)
+  * `image-type`: Image format ID (0 for all) __(optional)__
+* Options:
+  * `--delete`: Erase previous images before regenerating __(optional)__
+
+## Description
+
+This command aims to regenerate thumbnails via command line.
+
+## Examples
+
+### Regenerate products image types
+
+```bash
+$ bin/console prestashop:thumbnails:regenerate products
+```
+
+### Regenerate categories image types for image type ID 5
+```bash
+$ bin/console prestashop:thumbnails:regenerate categories 5
+```
+
+### Regenerate all image types and erase previous thumbnails
+```bash
+$ bin/console prestashop:thumbnails:regenerate all --delete
+```

--- a/development/components/console/prestashop-thumbnails-regenerate.md
+++ b/development/components/console/prestashop-thumbnails-regenerate.md
@@ -15,6 +15,8 @@ title: prestashop:thumbnails:regenerate
 
 ## Description
 
+Since {{< minver v="9.1.x" >}}.
+
 This command aims to regenerate thumbnails via command line.
 
 ## Examples


### PR DESCRIPTION
Introduces a markdown file detailing the usage of the `prestashop:thumbnails:regenerate` console command, including arguments, options, and example invocations for regenerating image thumbnails in PrestaShop.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | Documentation for https://github.com/PrestaShop/PrestaShop/pull/39478

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
