### PR TITLE
Fix whitespace and formatting in documentation

### DIFF
--- a/development/architecture/introduction.md
+++ b/development/architecture/introduction.md
@@ -8,7 +8,7 @@ summary: "Learn how PrestaShop is structured: back-end, front-end, business stac
 # Introduction to PrestaShop's Architecture
 
 PrestaShop is a big project, with several moving parts. In this article you will learn how they are structured and how they work together.
- 
+
 {{% notice note %}}
 Part of this article was originally published in 2019 as a [blog post](https://build.prestashop-project.org/news/prestashop-in-2019-and-beyond-part-1-current-architecture/). It has been updated and adapted for documentation purposes here.
 {{% /notice %}}
@@ -77,7 +77,7 @@ While controllers will be different in BO and FO, pretty much all of PrestaShop'
 - **Adapter code** – located in `/src/Adapter`
 - **Symfony code** (or "PrestaShop Bundle") – located in `/src/PrestaShopBundle`
 
-The **Legacy subsystem** contains the historical, non-namespaced code inherited from previous versions. It's [progressively being replaced since 1.6.1][architecture-1610] by the **Core subsystem**, which uses namespaces and is based on [SOLID principles][SOLID]. 
+The **Legacy subsystem** contains the historical, non-namespaced code inherited from previous versions. It's [progressively being replaced since 1.6.1][architecture-1610] by the **Core subsystem**, which uses namespaces and is based on [SOLID principles][SOLID].
 
 The **Adapter subsystem** acts as a bridge to legacy classes, which are often static, in order to [allow them to be injected][dependency-inversion] in Core classes.
 
@@ -128,7 +128,7 @@ FO controllers are all based on the `FrontController` class. Modules can declare
 
 #### BO Controllers
 
-BO controllers are a little more complex, since they can be either legacy or Symfony based. 
+BO controllers are a little more complex, since they can be either legacy or Symfony based.
 
 Legacy BO controllers are based on the `AdminController` class, whereas Symfony controllers are based on the `FrameworkBundleAdminController` class. Modules can declare BO controllers of their own, and they can be either legacy or symfony based as well. Legacy module controllers must extend the  `ModuleAdminController` class (which is based on `AdminController`), and Symfony modules must simply extend `FrameworkBundleAdminController`.
 
@@ -196,7 +196,7 @@ There are two kinds of themes in PrestaShop: **FO themes** and **BO themes**.
 
 ### FO themes
 
-FO themes define the appearance of the Front Office. 
+FO themes define the appearance of the Front Office.
 
 PrestaShop comes bundled with a default FO theme, called "Classic", but merchant can choose to use a different theme.
 
@@ -211,10 +211,10 @@ Unfortunately, _Classic_ [cannot be updated to recent Bootstrap versions](https:
 Additionally, FO themes can redefine the layout of modules by [overriding their templates][theme-module-override].
 
 ### BO themes
- 
+
 BO themes define the appearance of the Back Office.
 
-Even though BO themes are not interchangeable, PrestaShop comes bundled with two of them: **default** and **new theme**. 
+Even though BO themes are not interchangeable, PrestaShop comes bundled with two of them: **default** and **new theme**.
 
 So why are there two? Legacy controllers are based on Smarty, like FO controller. Symfony controllers, conversely, are based on the [Twig templating engine][twig]. As a result, there's a theme for each one: legacy controllers use the **default** theme, while Symfony ones use the **new theme**. As controllers are progressively being migrated to Symfony, templates are moved from the **default** to the **new theme** and converted from Smarty to Twig.
 
@@ -227,7 +227,7 @@ Here's what was said when [announcing the architecture of 1.7][introducing-symfo
 
 > Twig is Symfony's templating language. In version 1.7, it will be used for all pages that are rewritten to use Symfony [...], but NOT for the global interface (menu, header, etc.) nor the non-rewritten pages, which will still use Smarty. The two templating engines will be available, side by side, during the transition phase.
 
-This means that the global interface is handled by the **default** theme, _even in Symfony pages_. Because they use both Twig _and_ Smarty, this partially explains why some Symfony pages may sometimes be slower than legacy ones. 
+This means that the global interface is handled by the **default** theme, _even in Symfony pages_. Because they use both Twig _and_ Smarty, this partially explains why some Symfony pages may sometimes be slower than legacy ones.
 
 Rest assured, this is a _temporary issue_ which will be solved when everything has been migrated to Twig and Symfony.
 
@@ -272,7 +272,7 @@ As you can see, the module system has many features, making modules very powerfu
 ## Detailed diagram
 
 Now you know PrestaShop is much more complex than it can seem to be at first sight.
- 
+
 Remember the overview at the top of the article? Have a look at this more detailed version now:
 
 {{< figure src="../img/architecture-comprehensive-overview-current.png" title="Comprehensive overview" >}}

--- a/development/architecture/migration-guide/forms/CQRS-usage-in-forms.md
+++ b/development/architecture/migration-guide/forms/CQRS-usage-in-forms.md
@@ -8,7 +8,7 @@ weight: 30
 {{% notice note %}}
 This article assumes that you are already familiar with CQRS and [CRUD forms]({{< relref "CRUD-forms" >}}), as this topic only demonstrates the usage of the CQRS approach.
 {{% /notice %}}
- 
+
 ## The basics
 
 To use CQRS you need to:
@@ -123,9 +123,9 @@ public function create(array $data)
         $data['title'],
         $data['is_messages_saving_enabled']
     );
-    
+
     $contactId = $this->commandBus->handle($addContactCommand);
-    
+
     return $contactId->getValue();
 }
 ```

--- a/development/architecture/migration-guide/forms/CRUD-forms.md
+++ b/development/architecture/migration-guide/forms/CRUD-forms.md
@@ -21,9 +21,9 @@ This guide is intended for core developers and contributors who want to understa
 
 In computer programming, _CRUD_ is an acronym for the four basic functions of persistent storage: **create, read, update, and delete**.
 
-PrestaShop handles several logic objects, like Cart, Product, Order, Customer... among many others. When such objects are stored using a unique identifier, we refer to them as **identifiable objects**. 
+PrestaShop handles several logic objects, like Cart, Product, Order, Customer... among many others. When such objects are stored using a unique identifier, we refer to them as **identifiable objects**.
 
-In the Back Office, most identifiable objects are managed using forms and page listings that follow the CRUD pattern. When they do, we refer to those forms as **CRUD Forms**. 
+In the Back Office, most identifiable objects are managed using forms and page listings that follow the CRUD pattern. When they do, we refer to those forms as **CRUD Forms**.
 
 Since CRUD forms share a lot of common behavior, PrestaShop provides a common pattern to handle them all the same way. It is based on four main elements, each responsible for a very specific task:
 
@@ -43,11 +43,11 @@ The _Form Data Provider_ takes care of retrieving data to fill out a form. For t
 {{% funcdef %}}
 
 getData(mixed $id): array
-: 
+:
   Retrieves data for an edit form, using the given id to retrieve the object's data.
 
 getDefaultData(): array
-: 
+:
   Returns default data for a creation form.
 
 {{% /funcdef %}}
@@ -56,9 +56,9 @@ getDefaultData(): array
 
 To create a Form data provider you must implement the following interface:
 
-    \PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\FormDataProviderInterface 
+    \PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\FormDataProviderInterface
 
-In the example below, you can see a `ContactFormDataProvider` that queries the database (in this case, using `ObjectModel`) to retrieve data when a specific identifiable object id (in this case, `Contact`) is given, and that returns static data with defaults to use when creating a new element. 
+In the example below, you can see a `ContactFormDataProvider` that queries the database (in this case, using `ObjectModel`) to retrieve data when a specific identifiable object id (in this case, `Contact`) is given, and that returns static data with defaults to use when creating a new element.
 
 ```php
 <?php
@@ -78,7 +78,7 @@ final class ContactFormDataProvider implements FormDataProviderInterface
     public function getData($contactId)
     {
         $contactObjectModel = new Contact($contactId);
-        
+
         // check that the element exists in db
         if (empty($contactObjectModel->id)) {
             throw new PrestaShopObjectNotFoundException('Object not found');
@@ -104,7 +104,7 @@ final class ContactFormDataProvider implements FormDataProviderInterface
 ```
 
 {{% notice note %}}
-**This example has been simplified for practical reasons.** 
+**This example has been simplified for practical reasons.**
 
 The core actually uses the CQRS pattern to retrieve data, instead of `ObjectModel`. For more information, have a look at our recommended approach on [how to use CQRS in forms]({{< relref "CQRS-usage-in-forms" >}}).
 {{% /notice %}}
@@ -135,17 +135,17 @@ The _Form Builder_ is used by controllers to build the form that will be shown t
 
 It should be enough for most use cases, so you don't need to create it yourself! It also allows your form to be extended by modules.
 {{% /notice %}}
- 
+
 The common methods that you will be using are:
 
 {{% funcdef %}}
 
 getForm(array $data = [], array $options = []): FormInterface
-: 
+:
   Generates and returns the Symfony form. Additional `$data` and `$options` can be used in your form type.
 
 getFormFor(mixed $id, array $data = [], array $options = []): FormInterface
-: 
+:
   Generates and returns the Symfony form for an editable object which already exists and can be identified. Additional `$data` and `$options` can be used in your form type.
 
 {{% /funcdef %}}
@@ -165,19 +165,19 @@ prestashop.core.form.identifiable_object.builder.contact_form_builder:
     - '@prestashop.core.form.identifiable_object.data_provider.contact_form_data_provider'
 ```
 
-In the example above, we are declaring a specific service for this form based on PrestaShop's implementation of the Form Builder: 
+In the example above, we are declaring a specific service for this form based on PrestaShop's implementation of the Form Builder:
 
     PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder
-  
+
 ...which is instantiated using the base factory:
- 
+
  ```text
 prestashop.core.form.builder.form_builder_factory:create
 ```
 
 ...using two specific arguments:
 
-- The **Form Type**'s class name 
+- The **Form Type**'s class name
 - The **Form Data Provider**'s service name, that we declared previously.
 
 Finally, use it in your controller:
@@ -216,11 +216,11 @@ The _Form Data Handler_ is responsible for persisting the data submitted through
 {{% funcdef %}}
 
 create(array $data): mixed
-: 
+:
   Creates a new identifiable object using the provided data and returns the created object's id.
 
 update(mixed $id, array $data): void
-: 
+:
   Updates the object identified by `$id` using the provided data
 
 {{% /funcdef %}}
@@ -273,7 +273,7 @@ final class ContactFormDataHandler implements FormDataHandlerInterface
 ```
 
 {{% notice note %}}
-**This example has been simplified for practical reasons.** 
+**This example has been simplified for practical reasons.**
 
 The core actually uses the CQRS pattern to retrieve data, instead of `ObjectModel`. For more information, have a look at our recommended approach on [how to use CQRS in forms]({{< relref "CQRS-usage-in-forms" >}}).
 {{% /notice %}}
@@ -297,7 +297,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\FormDataHandl
 
 ## Form Handler
 
-The _Form Handler_ is in charge of validating, enriching and saving submitted form data, using the provided [Form Data Handler](#form-data-handler). 
+The _Form Handler_ is in charge of validating, enriching and saving submitted form data, using the provided [Form Data Handler](#form-data-handler).
 
 {{% notice tip %}}
 **PrestaShop provides a default implementation for this object.**
@@ -309,11 +309,11 @@ It provides two methods:
 
 {{% funcdef %}}
 handle(FormInterface $form): FormHandlerResultInterface
-: 
+:
   Saves form data by creating new instance of the related identifiable object.
 
 handleFor($id, FormInterface $form): FormHandlerResultInterface
-: 
+:
   Saves form data by updating the related object identified by `$id`.
 {{% /funcdef %}}
 
@@ -321,15 +321,15 @@ Both methods return an instance of `FormHandlerResultInterface` that provides in
 
 {{% funcdef %}}
 isValid(): bool
-: 
+:
   Indicates whether the form contains errors or not
 
 isSubmitted(): bool
-: 
+:
   Indicates if the form was submitted
-  
+
 getIdentifiableObjectId(): mixed
-: 
+:
   Returns the Id of the identifiable object created by the form submit, if applicable
 {{% /funcdef %}}
 
@@ -369,7 +369,7 @@ public function createAction(Request $request)
 {
     $contactFormBuilder = $this->get('prestashop.core.form.identifiable_object.builder.contact_form_builder');
     $contactForm = $contactFormBuilder->getForm();
-    
+
     $contactForm->handleRequest($request);
 
     $contactFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.contact_form_handler');
@@ -380,7 +380,7 @@ public function createAction(Request $request)
 
         return $this->redirectToRoute('admin_contacts_index');
     }
-    
+
     return $this->render('@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/create.html.twig', [
         'contactForm' => $contactForm->createView(),
     ]);
@@ -470,7 +470,7 @@ and
 ```
 
 {{% notice note %}}
-**This example has been simplified for practical reasons.** 
+**This example has been simplified for practical reasons.**
 
 The core actually uses CQRS to handle data persistence, which raises a `DomainException` in case of a constraint error (for example, if the identifiable object you are trying to edit doesn't exist). This is handled in the controller by wrapping the code in a try-catch block, then flashing an error message accordingly.
 

--- a/development/architecture/migration-guide/forms/settings-forms.md
+++ b/development/architecture/migration-guide/forms/settings-forms.md
@@ -46,7 +46,7 @@ The idea is to uncouple data management from Controllers, so populating the form
 ## Form Handlers
 
 Once you are able to manage data loaded to or sent by your forms, you need a way to build those forms (which can be themselves composed of multiple forms).
- 
+
 For this, you need a Form Handler. You can either implement it yourself as a class (based on the interface `PrestaShop\PrestaShop\Core\Form\FormHandlerInterface`), or use PrestaShop's core `FormHandler` to create a service in a declarative way – no need for a new class!
 
 As an example, here's how the Administration page's Form Handler service is declared:
@@ -68,17 +68,17 @@ prestashop.adapter.administration.general.form_handler:
 Let's look at the arguments one by one:
 
 - `'@form.factory'`
-    
+
     This is used to render the form. You can keep the default value.
-    
+
 - `'@prestashop.core.hook.dispatcher'`
 
     This is used to dispatch hooks related to the form. You can also keep this value by default.
-     
+
 - `'@prestashop.adapter.administration.form_provider'`
- 
+
     Here you need to specify your form's Data Provider.
- 
+
 - `'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralType'`is the FQCN of the form type you want to render in your form.
 
 - `'AdministrationPageGeneral'`
@@ -104,12 +104,12 @@ $form->handleRequest($request);
 if ($form->isSubmitted()) {
     $data = $form->getData();
     $saveErrors = $this->get('prestashop.adapter.performance.form_handler')->save($data);
-    
+
     if (0 === count($saveErrors)) {
         $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
         return $this->redirectToRoute('admin_performance');
     }
-    
+
     $this->flashErrors($saveErrors);
 }
 

--- a/development/architecture/migration-guide/hooks.md
+++ b/development/architecture/migration-guide/hooks.md
@@ -22,7 +22,7 @@ file_put_contents('hooks.txt', PHP_EOL. $hook_name, FILE_APPEND | LOCK_EX);
 ```
 
 After applying this change, access the url of the page you want to migrate. In ``admin-dev/hooks.txt``, you'll see the list of available hooks in the legacy page.
- 
+
 Now, create a simple module that hooks on each one of these hooks and renders something visible that you can retrieve in the new page.
 
 {{% notice note %}}
@@ -47,7 +47,7 @@ $this->dispatchHook('actionAdminPerformanceControllerPostProcessBefore', array('
 ## Dispatching hooks using the Hook dispatcher
 
 If you need to dispatch a hook from a non-controller class, you'll need to inject the [HookDispatcher](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Core/Hook/HookDispatcher.php) class.
- 
+
 If your class is defined as a Symfony service, the HookDispatcher is available as a service called `prestashop.core.hook.dispatcher`.
 
 ```php

--- a/development/architecture/migration-guide/templating-with-twig.md
+++ b/development/architecture/migration-guide/templating-with-twig.md
@@ -101,7 +101,7 @@ $this->trans('Before activating the webservice, you must be sure to: ', array(),
 
 ## Manage modern assets with Webpack
 
-PrestaShop uses Webpack to build and bundle static assets in PrestaShop, like Javascript and stylesheets. 
+PrestaShop uses Webpack to build and bundle static assets in PrestaShop, like Javascript and stylesheets.
 
 {{% notice note %}}
 The root folder for the modern theme is `/admin-dev/themes/new-theme`.

--- a/development/architecture/migration-guide/testing/behat.md
+++ b/development/architecture/migration-guide/testing/behat.md
@@ -127,7 +127,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
 
         SharedStorage::getStorage()->set($orderReference, $orderId->getValue());
     }
-    
+
 //    ...
 ```
 

--- a/development/architecture/modern/controller-routing.md
+++ b/development/architecture/modern/controller-routing.md
@@ -102,7 +102,7 @@ class SomeController extends FrameworkBundleAdminController
      * )
      *
      */
-    public function fooAction(Request $request) { 
+    public function fooAction(Request $request) {
         // action code
     }
 }
@@ -169,7 +169,7 @@ use PrestaShopBundle\Security\Annotation\DemoRestricted;
  *
  */
 public function fooAction(Request $request) {
-    // do something here  
+    // do something here
 }
 ```
 
@@ -265,7 +265,7 @@ route_name:
         _controller: 'PrestaShopBundle\Controller\Path\To\ControllerClass::{actionName}Action'
         _legacy_controller: LegacyController
         _legacy_link: {LegacyController}:{actionName}
-        
+
 # In some cases several controllers/actions are managed by the same migrated controller
 # You have the possibility to set an array as _legacy_link thus preventing you from defining alias routes
 other_route_name:
@@ -276,7 +276,7 @@ other_route_name:
         _legacy_controller: LegacyController
         _legacy_link:
             - {LegacyController}:{actionName}
-            - {LegacyController}:{aliasActionName}        
+            - {LegacyController}:{aliasActionName}
 ```
 
 The `actionName` part is optional for the **index** action (equivalent to **list**), therefore these three notations are equivalent:

--- a/development/coding-standards/_index.md
+++ b/development/coding-standards/_index.md
@@ -86,7 +86,7 @@ class MyClass
 {
     public function doStuff(string $foo, array $bar): void
     {
-    }   
+    }
 }
 ```
 
@@ -149,7 +149,7 @@ You can run the linter to help you comply with these coding standards:
 
 ## TypeScript
 
-All `admin-dev/themes/new-theme/js` files are coded in TypeScript. Classes and functions in .ts files must be strictly typed. 
+All `admin-dev/themes/new-theme/js` files are coded in TypeScript. Classes and functions in .ts files must be strictly typed.
 
 You are able to get global types in the `admin-dev/themes/new-theme/js/types` folder using the `@PSTypes` relative path and some types library are imported from npm using the `@types` namespace and automatically imported by TypeScript.
 

--- a/development/compile-assets.md
+++ b/development/compile-assets.md
@@ -11,7 +11,7 @@ Some components in PrestaShop, like Javascript or SCSS files, need to be compile
 
 We use [Webpack](https://webpack.js.org/) to compile assets. PrestaShop is using NodeJS ([get it here](https://nodejs.org/)), NPM will take care of it all.
 
-Here is a list of compatibility: 
+Here is a list of compatibility:
 
 | PrestaShop Versions | NodeJS Versions | NPM Versions |
 |---------------------|-----------------|--------------|

--- a/development/components/console/context-helper.md
+++ b/development/components/console/context-helper.md
@@ -28,7 +28,7 @@ MyCustomCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->getContainer()->get('prestashop.adapter.legacy_context_loader')->loadGenericContext();
-        
+
         ...
     }
 });

--- a/development/components/console/prestashop-linter-security-attribute.md
+++ b/development/components/console/prestashop-linter-security-attribute.md
@@ -20,5 +20,4 @@ Two options are available: Listing and Finding Missing.
 This option aims to list all routes, and their related permissions.
 
 ### Finding missing
-This option aims to find routes with missing security attributes.    
-
+This option aims to find routes with missing security attributes.

--- a/development/components/console/prestashop-list-commands-and-queries.md
+++ b/development/components/console/prestashop-list-commands-and-queries.md
@@ -13,4 +13,3 @@ title: prestashop:list:commands-and-queries
 This command aims to list all available CQRS commands and queries.
 
 That permits to list all classes, with their types (Command or Query) and their description.
-

--- a/development/components/database/dbquery.md
+++ b/development/components/database/dbquery.md
@@ -21,61 +21,61 @@ return Db::getInstance()->executeS($sql);
 {{% funcdef %}}
 
 __toString()
-: 
+:
     Generate and get the query.
 
 build()
-: 
+:
     Generate and get the query (return a string).
 
 from(string $table, mixed $alias = null)
-: 
+:
     Set table for FROM clause.
 
 groupBy(string $fields)
-: 
+:
     Add a GROUP BY restriction.
 
 having(string $restriction)
-: 	
+:
     Add a restriction in the HAVING clause (each restriction will be separated by an AND statement).
 
 innerJoin(string $table, string $alias = null, string $on = null)
-:  
+:
     Add a INNER JOIN clause<br>
     E.g. `$this->innerJoin('product p ON ...')`.
 
 join(string $join)
-:   
+:
     Add a JOIN clause<br>
     E.g. `$this->join('RIGHT JOIN'.DB_PREFIX.'produc t p ON ...');`.
 
 leftJoin(string $table, string $alias = null, string $on = null)
-: 
+:
     Add a LEFT JOIN clause.
 
 leftOuterJoin(string $table, string $alias = null, string $on = null)
-: 
+:
     Add a LEFT OUTER JOIN clause.
 
 limit(int $limit, int $offset = 0)
-: 
+:
     Limit results in query.
 
 naturalJoin(string $table, string $alias = null)
-: 
+:
     Add a NATURAL JOIN clause.
 
 orderBy(string $fields)
-: 
+:
     Add an ORDER BY restriction.
 
 select(string $fields)
-:  
+:
     Add fields in query selection.
 
 where(string $restriction)
-:  
+:
     Add a restriction in WHERE clause (each restriction will be separated by an AND statement).
 
 {{% /funcdef %}}

--- a/development/components/database/objectmodel.md
+++ b/development/components/database/objectmodel.md
@@ -18,19 +18,19 @@ Read more about Object relation mapping (ORM), Database abstraction layer (DBAL)
 - [Data access layer (DAL)](https://en.wikipedia.org/wiki/Data_access_layer)
 - [Active record pattern](https://en.wikipedia.org/wiki/Active_record_pattern)
 
-A class extending the ObjectModel class is tied to a database table. Its static attribute (`$definition`) represents the model. 
+A class extending the ObjectModel class is tied to a database table. Its static attribute (`$definition`) represents the model.
 
-Its instances are tied to database records. 
+Its instances are tied to database records.
 
-When instantiated with an `$id` in the class constructor, the attributes are retrieved from the related database record (using the `$id` as the primary key to find the table record). 
+When instantiated with an `$id` in the class constructor, the attributes are retrieved from the related database record (using the `$id` as the primary key to find the table record).
 
 {{% notice info %}}
-You can override classes that extend ObjectModel, but with extreme precaution, e.g., defining a wrong `$definition` model can break the entire system or lead to data loss. 
+You can override classes that extend ObjectModel, but with extreme precaution, e.g., defining a wrong `$definition` model can break the entire system or lead to data loss.
 {{% /notice %}}
 
 ## Create a new entity managed by ObjectModel
 
-You can create a new entity (in a module for example), with its own database table, managed by ObjectModel. 
+You can create a new entity (in a module for example), with its own database table, managed by ObjectModel.
 
 To do this, create class extending the ObjectModel:
 
@@ -122,14 +122,14 @@ public static $definition = [
     'fields' => array(
 ```
 
-- `table` is the related database table name (without the database table `PREFIX`), 
+- `table` is the related database table name (without the database table `PREFIX`),
 - `primary` is the name of the `PRIMARY KEY` field in the database table, which will be used as `$id` in the ObjectModel
 - `multilang` is a boolean value indicating that the entity is available in multiple langages, see [Multiple languages]({{< ref "#multiple-languages" >}})
 - `fields` is an array containing all other of the fields from the database table.
 
 ### Fields description
 
-A field is defined by a key (its name in the database table) and an array of its settings. 
+A field is defined by a key (its name in the database table) and an array of its settings.
 
 ```php
 'meta_description' => [
@@ -165,13 +165,13 @@ Field type is an important setting, it determines how ObjectModel will format yo
 
 #### Validation rules reference
 
-Several validation rules are available for your ObjectModel fields. 
+Several validation rules are available for your ObjectModel fields.
 [Please refer to the Validate class of PrestaShop](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/Validate.php) for a complete list.
 
 ### Add timestamps to your entity (date_add and date_upd)
 
-ObjectModel has a mechanism to handle creation/modification timestamps. 
-To use this feature, you have to define those two properties of your entity and set them up in the model definition. 
+ObjectModel has a mechanism to handle creation/modification timestamps.
+To use this feature, you have to define those two properties of your entity and set them up in the model definition.
 
 ```php
 class Cms extends ObjectModel
@@ -215,7 +215,7 @@ If the insert is successful, the ObjectModel class will set the entity's id (ret
 
 ```php
 $id = 2; // id of the object in database
-$cms = new Cms($id); 
+$cms = new Cms($id);
 $cms->position = 3;
 ...
 $cms->save();
@@ -225,7 +225,7 @@ In this example, we retrieve an entity from the database with its id. Then, we c
 
 ### Hard or soft delete an object
 
-Two delete mechanisms are available with ObjectModel: hard delete and soft delete. 
+Two delete mechanisms are available with ObjectModel: hard delete and soft delete.
 Hard-delete deletes the record from the database, while soft-delete sets a flag in the table's field indicating that this record is deleted.
 
 {{% notice info %}}
@@ -242,13 +242,13 @@ Soft deleting an object does not trigger **Delete** related hooks, but will trig
 
 ```php
 $id = 2; // id of the object in database
-$cms = new Cms($id); 
+$cms = new Cms($id);
 $cms->softDelete(); // sets the deleted property to true, and triggers an update() call
 ...
 $cms->delete(); // triggers a DELETE statement to the DBAL
 ```
 
-## Advanced usage 
+## Advanced usage
 
 ### Multiple languages objects{#multiple-languages}
 
@@ -257,7 +257,7 @@ PrestaShop's ObjectModel can handle translations (also called internationalizati
 #### Under the hood: how does it work?
 
 When declaring a multi-language ObjectModel, PrestaShop will fetch another database table named like your base database table, but with a suffix `_lang`
-This table references the id of the base Object (`id_cms`), the id of the language (`id_lang`), and each translatable field. 
+This table references the id of the base Object (`id_cms`), the id of the language (`id_lang`), and each translatable field.
 
 In our previous example, for `Cms` ObjectModel:
 
@@ -308,7 +308,7 @@ And then, you must declare which fields are available for translations:
 
 #### Accessors for translatable ObjectModels{#multiple-language-accessors}
 
-Translatable fields are available in your ObjectModel as `array`. 
+Translatable fields are available in your ObjectModel as `array`.
 In our example, to update the attributes `meta_title` for languages EN (`$lang_id=1`) and FR (`$lang_id=2`), use the following method :
 
 ```php
@@ -333,7 +333,7 @@ PrestaShop's ObjectModel can handle multiple stores (or multi shop) ObjectModels
 #### Under the hood: how does it work?
 
 When declaring a multi-store ObjectModel, PrestaShop will fetch another database table named like your base database table, with a suffix `_shop`
-This table is a pivot table referencing at least the id of the base Object (`id_cms`) and the id of the shop (`id_shop`). 
+This table is a pivot table referencing at least the id of the base Object (`id_cms`) and the id of the shop (`id_shop`).
 
 In our previous example, for `Cms` ObjectModel:
 
@@ -382,7 +382,7 @@ PrestaShop's ObjectModel can handle both multiple languages and multiple shop en
 #### Under the hood: how does it work?
 
 When declaring a multi-store ObjectModel, PrestaShop will fetch another database table named like your base database table, with a suffix `_shop`
-This table is a pivot table referencing at least the id of the base Object (`id_cms`) and the id of the shop (`id_shop`). 
+This table is a pivot table referencing at least the id of the base Object (`id_cms`) and the id of the shop (`id_shop`).
 
 In our previous example, for `Category` ObjectModel :
 
@@ -458,7 +458,7 @@ $category->save();
 To duplicate an object, use the following method : `duplicateObject()`
 
 ```php
-$cms = new Cms(2); 
+$cms = new Cms(2);
 $duplicatedCms = $cms->duplicateObject();
 ```
 
@@ -470,14 +470,14 @@ Please note that the `duplicateObject()` method will instantly save the duplicat
 
 ### Partial update of an object
 
-Since {{< minver v="8.x" >}}, a partial update mechanism is available in ObjectModel. This mechanism allows you to choose which attributes you want to update during the `update()` method call. 
+Since {{< minver v="8.x" >}}, a partial update mechanism is available in ObjectModel. This mechanism allows you to choose which attributes you want to update during the `update()` method call.
 
 On previous versions ({{< minver v="1.7.x" >}}, {{< minver v="1.6.x" >}}, ...), this method was already available but was not working properly.
 
 Example:
 
 ```php
-$cms = new Cms(2); 
+$cms = new Cms(2);
 $cms->position = 4;
 $cms->active = 0;
 $cms->setFieldsToUpdate(["position" => true]);
@@ -491,7 +491,7 @@ In this example, only the `position` is updated, `active` (and all other fields)
 You need to specify the language Ids you want to update, as an array :
 
 ```php
-$cms = new Cms(2); 
+$cms = new Cms(2);
 $cms->meta_title[1] = "My awesome title"; // language id #1
 $cms->meta_title[2] = "Mon fabuleux titre"; // language id #2
 $cms->setFieldsToUpdate(
@@ -507,8 +507,8 @@ $cms->save(); // only meta_title for language id #1 will be updated
 
 ### Toggle status
 
-A mecanism of state is available with ObjectModel : active / inactive state. 
-When triggered, this mecanism allows your entities to be enabled / disabled. 
+A mecanism of state is available with ObjectModel : active / inactive state.
+When triggered, this mecanism allows your entities to be enabled / disabled.
 
 {{% notice info %}}
 **Status is not always available.**
@@ -518,15 +518,15 @@ If the model object has no `active` property or no `active` definition field, a 
 
 ```php
 $id = 2; // id of the entity in database
-$cms = new Cms($id); 
+$cms = new Cms($id);
 $cms->toggleStatus(); // sets the active property to true or false (depending on its current value), and triggers an update() call
 ```
 
 ### Delete multiple entities
 
-You can delete multiple object at once with the `deleteSelection` method. Pass an array of IDs to delete to this method, and they will be deleted. 
+You can delete multiple object at once with the `deleteSelection` method. Pass an array of IDs to delete to this method, and they will be deleted.
 
-Usage : 
+Usage :
 
 ```php
 $cmsIdsToDelete = [1, 2, 3, 8, 10];
@@ -564,7 +564,7 @@ public function hookActionObjectProductDeleteAfter(Product $product)
 {
     PrestaShopLogger::addLog(
         sprintf('Product with id %s was deleted with success', $product->id_product)
-    );    
+    );
 }
 ```
 

--- a/development/components/database/prestashopcollection.md
+++ b/development/components/database/prestashopcollection.md
@@ -6,7 +6,7 @@ title: PrestaShopCollection class
 
 ## Introduction
 
-The PrestaShopCollection component is a Collection of ObjectModel objects. It implements common useful `PHP` interfaces: 
+The PrestaShopCollection component is a Collection of ObjectModel objects. It implements common useful `PHP` interfaces:
 
 - `Iterator`: allows for `foreach` loop on the Collection
 - `ArrayAccess`: allows for offset/index access on the Collection
@@ -31,7 +31,7 @@ if (count($productCollection) > 0) {
 
 ## Create a PrestaShopCollection
 
-To create a PrestaShopCollection, simply instantiate a PrestaShopCollection with the ObjectModel type as a constructor parameter. 
+To create a PrestaShopCollection, simply instantiate a PrestaShopCollection with the ObjectModel type as a constructor parameter.
 
 ```php
 use PrestaShopCollection;
@@ -67,9 +67,9 @@ $firstProduct = $productCollection->getFirst();
 $lastProduct = $productCollection->getLast();
 
 // you can access items in the collection by index, like in a regular array (this class implements ArrayAccess). The index starts at 0
-$thirdProduct = $productCollection[2]; 
+$thirdProduct = $productCollection[2];
 
-// The collection is also iterable (the class implements Iterator): 
+// The collection is also iterable (the class implements Iterator):
 foreach ($productCollection as $product) {
 
 }
@@ -80,7 +80,7 @@ count($productCollection);
 
 ## Filtering a Collection (where, having)
 
-When building the Collection, you may need to filter its content. To do so, use the `where()` method. 
+When building the Collection, you may need to filter its content. To do so, use the `where()` method.
 
 ```php
 public function where($field, $operator, $value, $method = 'where')
@@ -89,7 +89,7 @@ public function where($field, $operator, $value, $method = 'where')
 - `$field` is the field's name to filter
 - `$operator` is the operator to use for filtering (complete list below)
 - `$value` is the value to filter against (can be a scalar or array value)
-- `$method` is the method to use (defaults to `where`, or can be `having`, see below for more informations) 
+- `$method` is the method to use (defaults to `where`, or can be `having`, see below for more informations)
 
 ### List of operators
 
@@ -123,7 +123,7 @@ $productCollection->where('reference', 'LIKE', 'REF-%'); // find products with r
 
 ### `Having` method
 
-There is also `having()` method available, which calls `where()` with the parameter `$method` set to `having`. 
+There is also `having()` method available, which calls `where()` with the parameter `$method` set to `having`.
 
 ```php
 public function having($field, $operator, $value)
@@ -131,21 +131,21 @@ public function having($field, $operator, $value)
 
 ## Joining to associated entities (join)
 
-When building the Collection, you may need to join with other ObjectModel entities. 
-You can join on associations that are declared in the $definition of the ObjectModel. 
+When building the Collection, you may need to join with other ObjectModel entities.
+You can join on associations that are declared in the $definition of the ObjectModel.
 
 ```php
 public function join($association, $on = '', $type = null)
 ```
 
-Join `manufacturer` to your `Product` collection: 
+Join `manufacturer` to your `Product` collection:
 
 ```php
 $productCollection = new PrestaShopCollection('Product');
 $productCollection->join('manufacturer');
 ```
 
-You can join on a different field by specifying the field name as a second parameter: 
+You can join on a different field by specifying the field name as a second parameter:
 
 ```php
 $productCollection = new PrestaShopCollection('Product');
@@ -162,7 +162,7 @@ $productCollection->join('categories', 'id_category', PrestaShopCollection::LEFT
 
 ### Using `where` with `join`
 
-One of the interest of joining other ObjectModel entities to your collection, is the possibility to filter on the external entity with `where()`. 
+One of the interest of joining other ObjectModel entities to your collection, is the possibility to filter on the external entity with `where()`.
 
 ```php
 $productCollection = (new PrestaShopCollection('Product'))
@@ -172,7 +172,7 @@ $productCollection = (new PrestaShopCollection('Product'))
 
 ## Ordering a Collection (order by)
 
-To order your collection, use the `orderBy()` method. 
+To order your collection, use the `orderBy()` method.
 
 ```php
 public function orderBy($field, $order = 'asc')
@@ -216,26 +216,26 @@ $productCollection = (new PrestaShopCollection('Product'))
     ->setPageSize(100); // will get only 100 items
 ```
 
-If `$page_size` is set, the collection will return the first `$page_size` items. 
+If `$page_size` is set, the collection will return the first `$page_size` items.
 
 If you need to paginate and access the second page of a collection, you can use the following example:
 
 ```php
 $productCollection = (new PrestaShopCollection('Product'))
     ->setPageSize(100) // will get only 100 items
-    ->setPageNumber(2); // but from page 2, equivalent to offset=(pageNumber - 1) * page_size. 
+    ->setPageNumber(2); // but from page 2, equivalent to offset=(pageNumber - 1) * page_size.
 ```
 
-- Getting the page: `1` of a collection with a page_size of: `100` is the `PrestaShopCollection` equivalent of this `SQL` statement: 
+- Getting the page: `1` of a collection with a page_size of: `100` is the `PrestaShopCollection` equivalent of this `SQL` statement:
     `LIMIT 100` or `LIMIT 100 OFFSET 0` or `LIMIT 0,100`
 
-- Getting the page: `2` of a collection with a page_size of: `100` is the `PrestaShopCollection` equivalent of this `SQL` statement: 
+- Getting the page: `2` of a collection with a page_size of: `100` is the `PrestaShopCollection` equivalent of this `SQL` statement:
     `LIMIT 100 OFFSET 100` or `LIMIT 100,100`
 
-- Getting the page: `3` of a collection with a page_size of: `100` is the `PrestaShopCollection` equivalent of this `SQL` statement: 
+- Getting the page: `3` of a collection with a page_size of: `100` is the `PrestaShopCollection` equivalent of this `SQL` statement:
     `LIMIT 100 OFFSET 200` or `LIMIT 200,100`
 
 {{% notice info %}}
-Known issue: If the entity has multi-lang attributes, when not using `$id_lang` in the `PrestaShopCollection` constructor, and using pagination (`setPageSize()`, `setPageNumber()`), pagination will be broken. 
+Known issue: If the entity has multi-lang attributes, when not using `$id_lang` in the `PrestaShopCollection` constructor, and using pagination (`setPageSize()`, `setPageNumber()`), pagination will be broken.
 Please set an `$id_lang` in the constructor to use pagination features for entities with multi-lang attributes.
 {{% /notice %}}

--- a/development/components/export/csv-response.md
+++ b/development/components/export/csv-response.md
@@ -8,11 +8,11 @@ weight: 1
 
 # CsvResponse component
 
-Introduced in {{< minver v="1.7.3" >}}, this component allows to export data to CSV Format. 
+Introduced in {{< minver v="1.7.3" >}}, this component allows to export data to CSV Format.
 
 ## Usage of CsvResponse component
 
-To use this component, add a `use` statement in your module: 
+To use this component, add a `use` statement in your module:
 
 ```php
 use PrestaShopBundle\Component\CsvResponse;
@@ -42,7 +42,7 @@ $headersData = [
 You can remove columns from your export by ignoring them in `$headersData`.
 {{% /notice %}}
 
-Finally, create and return your `CsvResponse` export: 
+Finally, create and return your `CsvResponse` export:
 
 ```php
 return (new CsvResponse())
@@ -71,13 +71,13 @@ return (new CsvResponse())
 
 ### Advanced usage with a callback function to export large amounts of data (chunking)
 
-Sometimes you will need to export large parts of data with a large memory usage, that can cause performance issues. 
-To achieve this, you can't just query your database and retrieve your large amount of data. 
-You need to chunk your data, and build your csv export chunk by chunk. 
+Sometimes you will need to export large parts of data with a large memory usage, that can cause performance issues.
+To achieve this, you can't just query your database and retrieve your large amount of data.
+You need to chunk your data, and build your csv export chunk by chunk.
 
-Let's understand how to do this: 
+Let's understand how to do this:
 
-1) Create a `callback function`, with two parameters: `$offset` and `$limit`. 
+1) Create a `callback function`, with two parameters: `$offset` and `$limit`.
 
 ```php
 $dataCallback = function ($offset, $limit){
@@ -88,7 +88,7 @@ $dataCallback = function ($offset, $limit){
 
 This `callback function` returns a set of data from a repository (eg. a database), with `$offset` and `$limit` parameters (eg. a `LIMIT 0,5000` SQL query).
 
-2) Create your CsvResponse with your `callback function` as data: 
+2) Create your CsvResponse with your `callback function` as data:
 
 ```php
 return (new CsvResponse())
@@ -111,11 +111,11 @@ Since `$dataCallback` is a `callable`, `CsvResponse` will loop over your `callba
 There are two modes when retrieving data with a `callback function`:
 
 - `CsvResponse::MODE_OFFSET`: Your callback function is receiving `$offset` (index to start retrieving items at) and `$limit` (count of items to retrieve). This is the equivalent of MySql `LIMIT 0,100`, `LIMIT 100,100`, `LIMIT 200,100`.
-- `CsvResponse::MODE_PAGINATION`: Your callback function is receiving `$offset` (page number) and `$limit` (count of items to retrieve), and will handle its pagination itself. 
+- `CsvResponse::MODE_PAGINATION`: Your callback function is receiving `$offset` (page number) and `$limit` (count of items to retrieve), and will handle its pagination itself.
 
 The default mode is `MODE_PAGINATION`.
 
-When looping over your `callback function`, the `CsvResponse` is retrieving `$limit` items, while there are results. 
+When looping over your `callback function`, the `CsvResponse` is retrieving `$limit` items, while there are results.
 
 #### Mode pagination
 
@@ -151,7 +151,7 @@ return (new CsvResponse())
 
 ### Hide header line from export
 
-From {{< minver v="8.0" >}}, to disable header line from export, use the `setIncludeHeaderRow()` method. This method expects a boolean parameter indicating if the header line should be displayed or not. 
+From {{< minver v="8.0" >}}, to disable header line from export, use the `setIncludeHeaderRow()` method. This method expects a boolean parameter indicating if the header line should be displayed or not.
 
 ```php
 return (new CsvResponse())

--- a/development/components/form/_index.md
+++ b/development/components/form/_index.md
@@ -54,7 +54,7 @@ graph
 ### FormBuilder
 
 In most scenarios, the Controller initially instantiates the FormBuilder. This component constructs the necessary Form, incorporating all Form Types. It also retrieves data from the FormDataProvider, ensuring that the form is populated with the appropriate data.
-The `FormBuilder` will build the required `Form` with all `Form Types`, and retrieve data from the `FormDataProvider`. 
+The `FormBuilder` will build the required `Form` with all `Form Types`, and retrieve data from the `FormDataProvider`.
 
 ### FormDataProvider
 
@@ -66,16 +66,16 @@ The FormDataProvider is responsible for retrieving data from the Database. This 
 
 Developers have access to a wide range of field types ([see Symfony types](https://symfony.com/doc/4.4/reference/forms/types.html)) that come from the Symfony framework. Additionally, PrestaShop enhances this selection with its own reusable field types.
 
-A complete reference of PrestaShop form types can be found [here]({{< relref "/9/development/components/form/types-reference">}}). 
+A complete reference of PrestaShop form types can be found [here]({{< relref "/9/development/components/form/types-reference">}}).
 
 ### FormHandler
 
 The `FormHandler` is responsible of:
 
-- extracting the form data, 
+- extracting the form data,
 - triggering the `actionBeforeCreate<FormName>FormHandler`, `actionBeforeUpdate<FormName>FormHandler`, `actionAfterCreate<FormName>FormHandler` and `actionAfterUpdate<FormName>FormHandler` hooks
 - calling the `FormDataHandler`
-- returning a `FormHandlerResult` 
+- returning a `FormHandlerResult`
 
 ### FormDataHandler
 
@@ -93,7 +93,7 @@ To render forms in a clean and user-friendly way, PrestaShop extended Symfony's 
 
 ## Customize forms by modules
 
-### Concepts 
+### Concepts
 
 - `FormModifier`: This component is used to modify the Form, primarily for module integration.
 - `FormModifier` hook_: Connects the FormModifier to the form, enabling modifications.
@@ -141,7 +141,7 @@ graph
 
 A `FormModifier` (also known as `FormBuilderModifier`) allows you to alter the contents of a Form. It is particularly useful within modules, allowing developers to add, modify, or remove elements from the form as required.
 
-It's been implemented in an example module: [DemoProductForm2](https://github.com/PrestaShop/example-modules/blob/master/demoproductform2/src/Form/Modifier/ProductFormModifier.php). 
+It's been implemented in an example module: [DemoProductForm2](https://github.com/PrestaShop/example-modules/blob/master/demoproductform2/src/Form/Modifier/ProductFormModifier.php).
 
 ```php
 namespace PrestaShop\Module\DemoProductForm\Form\Modifier;
@@ -159,7 +159,7 @@ final class ProductFormModifier
         ?ProductId $productId,
         FormBuilderInterface $productFormBuilder
     ): void {
-        [...]        
+        [...]
     }
 ```
 
@@ -176,7 +176,7 @@ services:
 
 A `FormModifier` by itself will not affect a `Form` unless it is properly hooked. To ensure functionality, the `FormModifier` must be linked by implementing the [action<Object>FormBuilderModifier]({{<relref "/9/modules/concepts/hooks/list-of-hooks/action<FormName>FormBuilderModifier">}}).
 
-In the module, register the hook and implement the method, for example, for the `Product` entity: 
+In the module, register the hook and implement the method, for example, for the `Product` entity:
 
 ```php
 public function install()
@@ -196,7 +196,7 @@ public function hookActionProductFormBuilderModifier(array $params): void
 
 ### FormDataProviderDefaultData Hook
 
-The [`Action<FormName>FormDataProviderDefaultData` hook]({{<relref "/9/modules/concepts/hooks/list-of-hooks/action<FormName>FormDataProviderDefaultData">}}) allows your module to provide or modify the default values sent to forms. 
+The [`Action<FormName>FormDataProviderDefaultData` hook]({{<relref "/9/modules/concepts/hooks/list-of-hooks/action<FormName>FormDataProviderDefaultData">}}) allows your module to provide or modify the default values sent to forms.
 
 ```php
 public function install()
@@ -214,7 +214,7 @@ This hook has been implemented as an example in our [example-modules repository]
 
 ### FormDataProviderData Hook
 
-The [`Action<FormName>FormDataProviderData` hook]({{<relref "/9/modules/concepts/hooks/list-of-hooks/action<FormName>FormDataProviderData">}}) allows your module to provide or modify the values sent to forms. 
+The [`Action<FormName>FormDataProviderData` hook]({{<relref "/9/modules/concepts/hooks/list-of-hooks/action<FormName>FormDataProviderData">}}) allows your module to provide or modify the values sent to forms.
 
 ```php
 public function install()
@@ -248,7 +248,7 @@ graph TD
     subgraph "Update"
         BA(actionBeforeUpdate<strong>FormName</strong>FormHandler) --> BB(IdentifiableObject updated)
         BB --> BC(actionAfterUpdate<strong>FormName</strong>FormHandler)
-    end  
+    end
     subgraph "Create"
         A(actionBeforeCreate<strong>FormName</strong>FormHandler) --> B(IdentifiableObject created)
         B --> C(actionAfterCreate<strong>FormName</strong>FormHandler)
@@ -267,7 +267,7 @@ public function hookActionAfterUpdateCombinationFormFormHandler(array $params): 
 
 ## Examples
 
-You can find some examples of how to use forms in your modules to extend PrestaShop capabilities: 
+You can find some examples of how to use forms in your modules to extend PrestaShop capabilities:
 
 | Subject | Link |
 | --- | --- |

--- a/development/components/form/form-theme/form-pages.md
+++ b/development/components/form/form-theme/form-pages.md
@@ -58,7 +58,7 @@ Shop parameters > Search > Search > Add new / edit alias              |       |
 Shop parameters > Search > Tags > Add new / edit tag                  |       |
  | |
 **Catalog** | |
-Orders > Invoices                                                     | 1.7.5 | 
+Orders > Invoices                                                     | 1.7.5 |
 Orders > Delivery Slips                                               | 1.7.5 | 8.0
 Orders > Credit Slips                                                 | 1.7.7 | 1.7.8
 Shipping > Preferences                                                | 1.7.5 | 1.7.8
@@ -73,7 +73,7 @@ Catalog > Attributes & Features > Add new / edit attribute            |       |
 Catalog > Attributes & Features > Add new / edit attribute value      |       |
 Catalog > Discounts > Cart rules > Add new / edit catalog price rule  |       |
 Catalog > Discounts > Cart rules > Add new / edit cart rule           |       |
-Payment > Preferences                                                 | 1.7.5 | 
+Payment > Preferences                                                 | 1.7.5 |
 Customers > Addresses                                                 | 1.7.7 | 1.7.8
 Customers > Addresses > Add new / edit address                        | 1.7.7 | 1.7.8
 Customers > Customers                                                 | 1.7.6 | 1.7.8
@@ -81,7 +81,7 @@ Customers > Customers > View customer                                 | 1.7.6 | 
 Customers > Customers > Add new / edit customer                       | 1.7.6 | 1.7.8
 Customer Service > Order Messages > Add new / edit order message      | 1.7.7 | 1.7.8
 Customer Service > Customer Service                                   |       |
-Customer Service > Merchandise Returns > Edit                         | 8.0   | 
+Customer Service > Merchandise Returns > Edit                         | 8.0   |
  | |
 **Improve** | |
 Design > Theme & Logo > Add new theme                                 | 1.7.6 | 1.7.8

--- a/development/components/form/types-reference/change-password.md
+++ b/development/components/form/types-reference/change-password.md
@@ -20,7 +20,7 @@ Learn more about [Javascript components and how to use them]({{<relref "/9/devel
 ```php
 <?php
 // path/to/your/CustomType.php
-    
+
 use PrestaShopBundle\Form\Admin\Type\ChangePasswordType;
 use Symfony\Component\Form\AbstractType;
 

--- a/development/components/form/types-reference/country-choice.md
+++ b/development/components/form/types-reference/country-choice.md
@@ -31,7 +31,7 @@ use Symfony\Component\Form\AbstractType;
 class CustomType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
-    {        
+    {
         $builder->add('country', CountryChoiceType::class);
     }
 }

--- a/development/components/form/types-reference/formatted-textarea.md
+++ b/development/components/form/types-reference/formatted-textarea.md
@@ -14,7 +14,7 @@ Enables TinyMCE text editor on TextareaType.
 | limit    | int  | 21844         | Limit of characters in text field. By default value equals to max size of UTF-8 content available in MySQL text column |
 
 ## Required Javascript components
- 
+
 | Component                                                             | Description                         |
 |:----------------------------------------------------------------------|:------------------------------------|
 | TinyMCEEditor | Rich text editor |

--- a/development/components/form/types-reference/integer-min-max-filter.md
+++ b/development/components/form/types-reference/integer-min-max-filter.md
@@ -17,7 +17,7 @@ The `IntegerMinMaxFilterType` represents two `IntegerType` fields - one holds mi
 `*` - this type overrides `step` attribute to 1 due to not allow adding floating point numbers as available option.
 
 ## Required Javascript components
-    
+
 None.
 
 ## Preview example

--- a/development/components/form/types-reference/material-choice-table.md
+++ b/development/components/form/types-reference/material-choice-table.md
@@ -29,7 +29,7 @@ Learn more about [Javascript components and how to use them]({{<relref "/9/devel
 ```php
 <?php
 // path/to/your/CustomType.php
-    
+
 use PrestaShopBundle\Form\Admin\Type\MaterialChoiceTableType;
 use Symfony\Component\Form\AbstractType;
 

--- a/development/components/form/types-reference/money-with-suffix.md
+++ b/development/components/form/types-reference/money-with-suffix.md
@@ -14,7 +14,7 @@ The `MoneyWithSuffixType` represents input with currency suffix.
 | suffix   | string | Empty string | Suffix text       |
 
 ## Required Javascript components
-    
+
 None.
 
 ## Code example

--- a/development/components/form/types-reference/navigation-tab-type.md
+++ b/development/components/form/types-reference/navigation-tab-type.md
@@ -16,13 +16,13 @@ This form type is used as a container of sub forms, each sub form will be render
 
 ## Usage and description
 
-This form type [was introduced in {{< minver v="8.1.0">}}](https://github.com/PrestaShop/PrestaShop/pull/28752) in the new product page. 
+This form type [was introduced in {{< minver v="8.1.0">}}](https://github.com/PrestaShop/PrestaShop/pull/28752) in the new product page.
 
 The new product page is based on this form type.
 
 Its usage has been documented in an example module: [`demoproductform`](https://github.com/PrestaShop/example-modules/tree/master/demoproductform).
 
-The module hooks to `actionProductFormBuilderModifier` to modify the `FormBuilder` for the Product page. 
+The module hooks to `actionProductFormBuilderModifier` to modify the `FormBuilder` for the Product page.
 The `ProductFormModifier` adds a new `CustomTabType` (created by the module) to the `FormBuilder` (which is a `NavigationTabType`).
 
 ```php
@@ -39,7 +39,7 @@ $this->formBuilderModifier->addAfter(
 );
 ```
 
-This `CustomTabType` contains a simple form type: 
+This `CustomTabType` contains a simple form type:
 
 ```php
 public function buildForm(FormBuilderInterface $builder, array $options)

--- a/development/components/form/types-reference/number-min-max-filter.md
+++ b/development/components/form/types-reference/number-min-max-filter.md
@@ -15,7 +15,7 @@ The `NumberMinMaxFilterType` represents two `NumberType` fields - one holds mini
 | max_field_options | array | array ( 'attr' => array ( 'placeholder' => $this->trans('Max', [], 'Admin.Global')), )   | Accepts all possible values that `NumberType` has      |
 
 ## Required Javascript components
-    
+
 None.
 
 ## Code example

--- a/development/components/form/types-reference/shop-choice-tree.md
+++ b/development/components/form/types-reference/shop-choice-tree.md
@@ -13,7 +13,7 @@ The `ShopChoiceTreeType` is subtype of `MaterialChoiceTreeType` which is configu
 | multiple | bool | `true`  | Whether multiple shops can be selected or not. |
 
 ## Required Javascript components
-    
+
 | Component                                                    | Description                        |
 | ------------------------------------------------------------ | ---------------------------------- |
 | ChoiceTree | Manages interaction of choice tree |

--- a/development/components/form/types-reference/switch.md
+++ b/development/components/form/types-reference/switch.md
@@ -14,7 +14,7 @@ The `SwitchType` displays a switch with Yes/No values.
 | disabled   | bool | `false`  | Whether Switch should be disabled or not |
 
 ## Required Javascript components
-    
+
 None.
 
 ## Code example

--- a/development/components/form/types-reference/text-with-length-counter.md
+++ b/development/components/form/types-reference/text-with-length-counter.md
@@ -15,7 +15,7 @@ The `TextWithLengthCounterType` represents text input with value length counter.
 | input      | string | `text`                   | Configured input type `text` or `textarea`                                   |
 
 ## Required Javascript components
-    
+
 | Component                                                                 | Description                           |
 | ------------------------------------------------------------------------- | ------------------------------------- |
 | TextWithLengthCounter | Calculates remaining length for input |

--- a/development/components/form/types-reference/text-with-recommended-length-type.md
+++ b/development/components/form/types-reference/text-with-recommended-length-type.md
@@ -13,7 +13,7 @@ It is used to add a field with a recommended input length counter to the form.
 
 | Option       | Type   | Default value                     | Description                                                                               |
 | :----------- | :----- | :-------------------------------- | :---------------------------------------------------------------------------------------- |
-| recommended_length | `int` | 
+| recommended_length | `int` |
 
 ## Required Javascript components
 
@@ -60,4 +60,3 @@ $builder->add('meta_description', TranslatableType::class, [
 ## Preview example
 
 {{< figure src="../img/text-with-recommended-length-type.png" title="TextWithRecommendedLengthType rendered in form" >}}
-

--- a/development/components/form/types-reference/translatable.md
+++ b/development/components/form/types-reference/translatable.md
@@ -19,7 +19,7 @@ If you wish to use [FormattedTextareaType]({{< relref "/9/development/components
 {{% /notice %}}
 
 ## Required Javascript components
-    
+
 | Component                                                      | Description                                 |
 | -------------------------------------------------------------- | ------------------------------------------- |
 | TranslatableInput | Allows toggling input for different locales |

--- a/development/components/form/types-reference/unit-type-extension.md
+++ b/development/components/form/types-reference/unit-type-extension.md
@@ -15,7 +15,7 @@ The `UnitTypeExtension` used with `NumberType` or `IntegerType` represents a num
 | unit   | string | `unit`  | Type of unit (e.g. Kg, Cm & etc) |
 
 ## Required Javascript components
-    
+
 None.
 
 ## Code example

--- a/development/components/form/types-reference/yes-and-no-choice.md
+++ b/development/components/form/types-reference/yes-and-no-choice.md
@@ -14,7 +14,7 @@ The `YesAndNoChoiceType` represents `select` input with options `Yes` and `No`.
 | required | boolean | false   | Whether field is required or not      |
 
 ## Required Javascript components
-    
+
 None.
 
 ## Code example

--- a/development/components/form/types-reference/zone-choice-type.md
+++ b/development/components/form/types-reference/zone-choice-type.md
@@ -19,7 +19,7 @@ Class is responsible for providing configurable zone choices with -- symbol in f
 - [StateGridDefinitionFactory](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Core/Grid/Definition/Factory/StateGridDefinitionFactory.php#L203-L209)
 
 ```php
-return (new FilterCollection())    
+return (new FilterCollection())
     ->add(
         (new Filter('id_zone', ZoneChoiceType::class))
         ->setTypeOptions([

--- a/development/internationalization/localization-packs.md
+++ b/development/internationalization/localization-packs.md
@@ -26,14 +26,14 @@ This can be done following two steps:
 
 * Update **the JSON configuration** of the PrestaShop project
 * Update i18n.prestashop.com content
-  
+
 ### Update required JSON configuration files in the PrestaShop project
 
 In PrestaShop, processing of languages is controlled by JSON configuration:
 
 * `app/Resources/all_languages.json`
 * `app/Resources/legacy-to-standard-locales.json`
-  
+
 The first one is used for listing languages supported by PrestaShop in back office.
 
 The second one is used to match the legacy 2-letter codes used for locales to the standard IETF language tags.
@@ -53,7 +53,7 @@ The item is filled with key/values relative to the localization :
 * `language_code` : Language code
 * `locale` : ISO code (5 characters) : two-letter language code ([ISO 639-1][iso-639-1]) and the two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))
 
-This is a sample : 
+This is a sample :
 ```json
   "da": {
     "name": "Dansk (Danish)",
@@ -72,7 +72,7 @@ In this file, you need to add a key/value.
 
 The key is the ISO code, based on the ISO-639-1 standard ([see an unofficial list here][iso-639-1]). The value is the locale.
 
-This is a sample : 
+This is a sample :
 ```json
   "da": "da-DK"
 ```
@@ -87,12 +87,12 @@ This content of i18n.prestashop.com is controlled by the GitHub repository [Pres
 
 The list of available languages is controlled by the file `available_languages.json` of the current version.
 
-You must submit a Pull Request in which you add a key/value: 
+You must submit a Pull Request in which you add a key/value:
 
 * The key is the locale of the language
 * The value is the name of the language which be displayed in the back office.
 
-This is a sample : 
+This is a sample :
 ```json
   "da-DK": "Danish (Denmark)"
 ```

--- a/development/internationalization/rtl.md
+++ b/development/internationalization/rtl.md
@@ -5,7 +5,7 @@ title: Right-To-Left languages
 # Right-to-Left languages
 
 PrestaShop supports Right-to-Left (RTL) languages natively, both in the Back Office and the Front Office. It can automatically transform themes to make them compatible with RTL languages.
- 
+
 Any Front Office theme can be transformed automatically by PrestaShop. Read "[RTL support][rtl-support]" in the Themes section to learn more about this system.
 
 ## Back Office support
@@ -15,7 +15,7 @@ The Back Office uses the same "theme-flipping" system as the Front Office featur
 ### Regenerating the RTL theme
 
 {{% notice note %}}
-This assumes you have read the "RTL support" article linked above. 
+This assumes you have read the "RTL support" article linked above.
 {{% /notice %}}
 
 {{% notice info %}}
@@ -28,8 +28,8 @@ If you changed something in your Back Office theme and you want your change to b
 2. Go to _International > Localization_, then click the "Languages" tab.
 3. Edit any language.
 4. Toggle the "Is RTL language" (see figure below) to "Yes" and save.\
-   If the language was already RTL, toggle it to "No" and save before changing it back to "Yes". 
+   If the language was already RTL, toggle it to "No" and save before changing it back to "Yes".
 
-{{< figure src="../img/rtl-edit-language.png" title="Toggling RTL for a language" >}}  
+{{< figure src="../img/rtl-edit-language.png" title="Toggling RTL for a language" >}}
 
 [rtl-support]: {{< ref "/9/themes/reference/rtl" >}}

--- a/development/multistore/shop-context/_index.md
+++ b/development/multistore/shop-context/_index.md
@@ -70,7 +70,7 @@ $isSingleShopContext = $shopContext->isSingleShopContext();
 // Is "all shops" context
 $isAllShopContext = $shopContext->isAllContext();
 
-// Get a list of IDs for all shops belonging to the current context (useful is the current context is a group) 
+// Get a list of IDs for all shops belonging to the current context (useful is the current context is a group)
 $shopList = $shopContext->getContextListShopID();
 
 // Get the id of the shop in the current context (useful if the current context is a single shop)

--- a/development/naming-conventions/_index.md
+++ b/development/naming-conventions/_index.md
@@ -220,9 +220,8 @@ PrestaShop comes with a lot of Grids (Products, Customers, Orders & etc) and kee
 
 ## Modules
 
-- Module names should contain only lower case and numbers. 
-- [Native modules][native-modules]' names must be prefixed with "ps_" (e.g. `ps_linklist`).  
+- Module names should contain only lower case and numbers.
+- [Native modules][native-modules]' names must be prefixed with "ps_" (e.g. `ps_linklist`).
 
 [native-modules]: {{< relref "../native-modules/" >}}
 [coding-standards]: {{< ref "/9/development/coding-standards/" >}}
-

--- a/development/native-modules/_index.md
+++ b/development/native-modules/_index.md
@@ -11,7 +11,7 @@ These modules are bundled into PrestaShop through composer at build time.
 
 ## List of native modules
 
-Module | Name | Native since | Description 
+Module | Name | Native since | Description
 ------ | ---- | ------------ | -----------
 [blockreassurance](https://github.com/PrestaShop/blockreassurance)                 | Customer reassurance block     | 1.7.0 | Adds an information block aimed at offering helpful information to reassure customers that your store is trustworthy.
 [blockwishlist](https://github.com/PrestaShop/blockwishlist)                       | Wishlist                       | 1.7.6 | Allow customers to create wishlists to save their favorite products for later.
@@ -19,7 +19,7 @@ Module | Name | Native since | Description
 [dashactivity](https://github.com/PrestaShop/dashactivity)                         | Activity dashboard widget      | 1.6.0 | Displays an activity widget in the Back office dashboard.
 [dashgoals](https://github.com/PrestaShop/dashgoals)                               | Dashboard goals                | 1.6.0 | Adds a block with your store's forecast.
 [dashproducts](https://github.com/PrestaShop/dashproducts)                         | Dashboard products             | 1.6.0 | Adds a block with a table of your latest orders and a ranking of your products.
-[dashtrends](https://github.com/PrestaShop/dashtrends)                             | Dashboard trends               | 1.6.0 | Adds a block with the evolution of your stores main numbers along with a graphic.                                                                                    
+[dashtrends](https://github.com/PrestaShop/dashtrends)                             | Dashboard trends               | 1.6.0 | Adds a block with the evolution of your stores main numbers along with a graphic.
 [gridhtml](https://github.com/PrestaShop/gridhtml)                                 | Simple HTML table display      | 1.6.0 | Allows the statistics system to display data in a grid.
 [gsitemap](https://github.com/PrestaShop/gsitemap)                                 | Google sitemap                 | 1.7.0 | Generate your Google sitemap file
 [pagesnotfound](https://github.com/PrestaShop/pagesnotfound)                       | Pages not found                | 1.4.0 | Adds a tab to the Stats dashboard, showing the pages requested by your visitors that have not been found.
@@ -33,7 +33,7 @@ Module | Name | Native since | Description
 [ps_customeraccountlinks](https://github.com/PrestaShop/ps_customeraccountlinks)   | Customer account links         | 1.7.0 | Displays a block with links relative to a user's account.
 [ps_customersignin](https://github.com/PrestaShop/ps_customersignin)               | Customer "sign in" link        | 1.7.0 | Adds a block that displays information about the customer.
 [ps_customtext](https://github.com/PrestaShop/ps_customtext)                       | Custom text                    | 1.7.0 | Adds custom text in your store.
-[ps_dataprivacy](https://github.com/PrestaShop/ps_dataprivacy)                     | Customer data privacy block    | 1.7.7 | Adds a block displaying your data privacy policy for more transparency and reassurance. 
+[ps_dataprivacy](https://github.com/PrestaShop/ps_dataprivacy)                     | Customer data privacy block    | 1.7.7 | Adds a block displaying your data privacy policy for more transparency and reassurance.
 [ps_emailsubscription](https://github.com/PrestaShop/ps_emailsubscription)         | Email subscription form        | 1.7.0 | Adds a block for newsletter subscription.
 [ps_facetedsearch](https://github.com/PrestaShop/ps_facetedsearch)                 | Faceted search                 | 1.7.0 | Displays a block with layered navigation filters.
 [ps_faviconnotificationbo](https://github.com/PrestaShop/ps_faviconnotificationbo) | Order Notifications on the Favicon | 1.7.5 | Displays a small icon over the favicon, only in back office, showing the number of notifications.
@@ -77,7 +77,7 @@ Module | Name | Native since | Description
 A few modules have been split between 1.6 & 1.7 versions of PrestaShop, as listed here:
 
 Original module for PrestaShop 1.6 | Updated module for PrestaShop 1.7 | Native in 1.7
------------------------------------|-----------------------------------| :-------------: 
+-----------------------------------|-----------------------------------| :-------------:
 [advancedeucompliance](https://github.com/PrestaShop/advancedeucompliance) | [ps_legalcompliance](https://github.com/PrestaShop/ps_legalcompliance) | ❌ No
 [bankwire](https://github.com/PrestaShop/bankwire) | [ps_wirepayment](https://github.com/PrestaShop/ps_wirepayment) | ✅ Yes
 [blockadvertising](https://github.com/PrestaShop/blockadvertising) | [ps_advertising](https://github.com/PrestaShop/ps_advertising) | ❌ No
@@ -100,21 +100,21 @@ Original module for PrestaShop 1.6 | Updated module for PrestaShop 1.7 | Native 
 [blocksearch](https://github.com/PrestaShop/blocksearch) | [ps_searchbar](https://github.com/PrestaShop/ps_searchbar) | ✅ Yes
 [blocksocial](https://github.com/PrestaShop/blocksocial) | [ps_socialfollow](https://github.com/PrestaShop/ps_socialfollow) | ✅ Yes
 [blockspecials](https://github.com/PrestaShop/blockspecials) | [ps_specials](https://github.com/PrestaShop/ps_specials) | ❌ No
-[blocksupplier](https://github.com/PrestaShop/blocksupplier) | [ps_supplierlist](https://github.com/PrestaShop/ps_supplierlist) | ❌ No 
+[blocksupplier](https://github.com/PrestaShop/blocksupplier) | [ps_supplierlist](https://github.com/PrestaShop/ps_supplierlist) | ❌ No
 [blocktopmenu](https://github.com/PrestaShop/blocktopmenu) | [ps_mainmenu](https://github.com/PrestaShop/ps_mainmenu) | ✅ Yes
 [blockuserinfo](https://github.com/PrestaShop/blockuserinfo) | [ps_customersignin](https://github.com/PrestaShop/ps_customersignin) | ✅ Yes
 [blockviewed](https://github.com/PrestaShop/blockviewed) | [ps_viewedproduct](https://github.com/PrestaShop/ps_viewedproduct) | ❌ No
-[carriercompare](https://github.com/PrestaShop/carriercompare) | [ps_carriercomparison](https://github.com/PrestaShop/ps_carriercomparison) | ❌ No 
-[cashondelivery](https://github.com/PrestaShop/cashondelivery) | [ps_cashondelivery](https://github.com/PrestaShop/ps_cashondelivery) | ❌ No 
+[carriercompare](https://github.com/PrestaShop/carriercompare) | [ps_carriercomparison](https://github.com/PrestaShop/ps_carriercomparison) | ❌ No
+[cashondelivery](https://github.com/PrestaShop/cashondelivery) | [ps_cashondelivery](https://github.com/PrestaShop/ps_cashondelivery) | ❌ No
 [cheque](https://github.com/PrestaShop/cheque) | [ps_checkpayment](https://github.com/PrestaShop/ps_checkpayment) | ✅ Yes
 [crossselling](https://github.com/PrestaShop/crossselling) | [ps_crossselling](https://github.com/PrestaShop/ps_crossselling) | ✅ Yes
 [feeder](https://github.com/PrestaShop/feeder) | [ps_feeder](https://github.com/PrestaShop/ps_feeder) | ❌ No
-[followup](https://github.com/PrestaShop/followup/) | [ps_reminder](https://github.com/PrestaShop/ps_reminder) | ❌ No 
+[followup](https://github.com/PrestaShop/followup/) | [ps_reminder](https://github.com/PrestaShop/ps_reminder) | ❌ No
 [ganalytics](https://github.com/PrestaShop/ganalytics) | [ps_googleanalytics](https://github.com/PrestaShop/ps_googleanalytics) | ❌ No
 [homefeatured](https://github.com/PrestaShop/homefeatured) | [ps_featuredproducts](https://github.com/PrestaShop/ps_featuredproducts) | ✅ Yes
 [homeslider](https://github.com/PrestaShop/homeslider) | [ps_imageslider](https://github.com/PrestaShop/ps_imageslider) | ✅ Yes
 [mailalerts](https://github.com/PrestaShop/mailalerts) | [ps_emailalerts](https://github.com/PrestaShop/ps_emailalerts) | ❌ No
 [onboarding](https://github.com/PrestaShop/onboarding) | [welcome](https://github.com/PrestaShop/welcome) | ✅ Yes
-[productscategory](https://github.com/PrestaShop/productscategory) | [ps_categoryproducts](https://github.com/PrestaShop/ps_categoryproducts) | ❌ No 
-[producttooltip](https://github.com/PrestaShop/producttooltip) | [ps_productinfo](https://github.com/PrestaShop/ps_productinfo) | ❌ No 
+[productscategory](https://github.com/PrestaShop/productscategory) | [ps_categoryproducts](https://github.com/PrestaShop/ps_categoryproducts) | ❌ No
+[producttooltip](https://github.com/PrestaShop/producttooltip) | [ps_productinfo](https://github.com/PrestaShop/ps_productinfo) | ❌ No
 [socialsharing](https://github.com/PrestaShop/socialsharing) | [ps_sharebuttons](https://github.com/PrestaShop/ps_sharebuttons) | ✅ Yes

--- a/development/orders-lifecycle/_index.md
+++ b/development/orders-lifecycle/_index.md
@@ -14,12 +14,12 @@ Orders can be created from a Cart, either in Front Office (FO) by the Customer o
 
 ### Cart in Front Office
 
-The Cart is created in database once first Product is being added into it. 
+The Cart is created in database once first Product is being added into it.
 - If Customer is not signed in (Guest), and he adds a Product to Cart, the Cart is created, but not associated to a Customer.
 - If a Guest already has a Cart and signs in, the Cart is assigned to him instead of creating a new one.
 
 {{% notice note %}}
-When a Customer signs-in, has an empty Cart in its Cookie (or does not have a Cart) and has a previous non ordered Cart in its profile, the default behaviour of PrestaShop is to reload its most recent non ordered Cart. That behaviour can be adjusted in `Configure -> Shop parameters -> Customer settings`, the related setting is `PS_CART_FOLLOWING` : `Re-display cart at login`. 
+When a Customer signs-in, has an empty Cart in its Cookie (or does not have a Cart) and has a previous non ordered Cart in its profile, the default behaviour of PrestaShop is to reload its most recent non ordered Cart. That behaviour can be adjusted in `Configure -> Shop parameters -> Customer settings`, the related setting is `PS_CART_FOLLOWING` : `Re-display cart at login`.
 This setting is implemented in: [Context.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/Context.php#L365).
 {{% /notice %}}
 
@@ -64,17 +64,17 @@ flowchart TB
 Please note that if a Cart contains only Virtual Products, there is no `checkout-addresses-step` and `checkout-delivery-step`. It goes directly from `checkout-personal-information-step` to `checkout-payment-step`.
 {{% /notice %}}
 
-1. **Associate to Customer** (checkout-personal-information-step): details like name, email, birthday, etc. In Front Office you can either fill 
-   this information manually as a guest (and optionally create a new Customer account) or log in as an existing Customer. 
+1. **Associate to Customer** (checkout-personal-information-step): details like name, email, birthday, etc. In Front Office you can either fill
+   this information manually as a guest (and optionally create a new Customer account) or log in as an existing Customer.
    If you create an Order from Back Office, you will be asked to select an existing Customer before modifying the existing Cart or creating a new one.
-2. **Select shipping and invoice addresses** (checkout-addresses-step): provide the shipping and invoice addresses information. 
+2. **Select shipping and invoice addresses** (checkout-addresses-step): provide the shipping and invoice addresses information.
    The shipping (a.k.a. delivery) address is where the Ordered Products should be sent, while the invoice address is used as a document billing address.
-   In Front Office, you can provide one address to be used as both - shipping and invoice. In Back Office, you must select shipping and invoice addresses 
-   (the same address can also be selected for both - shipping and invoices). 
+   In Front Office, you can provide one address to be used as both - shipping and invoice. In Back Office, you must select shipping and invoice addresses
+   (the same address can also be selected for both - shipping and invoices).
 3. **Select a shipping method** (checkout-delivery-step): after this step is complete, you will need to select one of the available Carriers
-   (Carriers are searched by delivery address, sometimes the total weight of the Products, their prices, and information about the Customer (a group to which the Customer belongs) and can be modified by Shop Employees on Improve -> Shipping -> Carriers page). 
+   (Carriers are searched by delivery address, sometimes the total weight of the Products, their prices, and information about the Customer (a group to which the Customer belongs) and can be modified by Shop Employees on Improve -> Shipping -> Carriers page).
    Note that the Carrier will not be available if a selected country or zone is disabled (in Back Office International -> Locations) or Carrier shipping and locations settings are not configured.
-3. **Select payment method** (checkout-payment-step): choose how to pay for the Order. Shop Employees can configure payment methods in 
+3. **Select payment method** (checkout-payment-step): choose how to pay for the Order. Shop Employees can configure payment methods in
    Back Office `Payment -> Payment methods`.
    All payments are handled by payment modules. PrestaShop comes with 3 [payment modules]({{< relref "/9/modules/payment" >}}) by default:
 
@@ -111,7 +111,7 @@ click `More actions -> Send pre-filled Order to the Customer by email` in summar
 {{% /notice %}}
 
 {{% notice note %}}
-**Dive more in PrestaShop's Checkout process:** 
+**Dive more in PrestaShop's Checkout process:**
 Learn how it works under the hood by looking at:
 - [classes/checkout/CheckoutSession.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/checkout/CheckoutSession.php)
 - [classes/checkout/CheckoutProcess.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/checkout/CheckoutProcess.php)

--- a/development/products-lifecycle/search-index.md
+++ b/development/products-lifecycle/search-index.md
@@ -33,7 +33,7 @@ classDiagram
         int id_word
         int id_shop
         int id_lang
-        varchar word    
+        varchar word
     }
 </div>
 
@@ -61,7 +61,7 @@ There are several actions that can trigger a reindex of a product or the complet
 
 Almost every field / information in the product is weighted to fine tune result relevance.
 
-The weight of fields is adjustable from the `Back Office > Shop Parameters > Search` with the configuration keys below: 
+The weight of fields is adjustable from the `Back Office > Shop Parameters > Search` with the configuration keys below:
 
 | Field | Configuration key | Default weight | Description |
 | --- | --- | --- | --- |


### PR DESCRIPTION
This commit standardizes whitespace, removes trailing spaces, and improves formatting across multiple documentation files for consistency and readability. No content changes were made.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
