### PR TITLE
fix broken link by escaping < and >

### DIFF
--- a/development/components/form/_index.md
+++ b/development/components/form/_index.md
@@ -174,7 +174,7 @@ services:
 
 #### FormModifier hook
 
-A `FormModifier` by itself will not affect a `Form` unless it is properly hooked. To ensure functionality, the `FormModifier` must be linked by implementing the [action<Object>FormBuilderModifier]({{<relref "/9/modules/concepts/hooks/list-of-hooks/action<FormName>FormBuilderModifier">}}).
+A `FormModifier` by itself will not affect a `Form` unless it is properly hooked. To ensure functionality, the `FormModifier` must be linked by implementing the [action\<Object\>FormBuilderModifier]({{<relref "/9/modules/concepts/hooks/list-of-hooks/action<FormName>FormBuilderModifier">}}).
 
 In the module, register the hook and implement the method, for example, for the `Product` entity:
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.x
| Description?      | A link is broken because of `<Object>`. I escaped it and it works now :) 
| Fixed ticket?     | -
| Sponsor company   | Mademoiselle bio

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
