### PR TITLE
Fix ActionColumn example to use RowActionCollection

### DIFF
--- a/development/components/grid/columns-reference/action.md
+++ b/development/components/grid/columns-reference/action.md
@@ -37,7 +37,6 @@ $actionColumn->setOptions([
                 'confirm_message' => 'Delete selected item?',
             ])
         )
-     ],
 ]);
 
 $columns = new ColumnCollection();

--- a/development/components/grid/columns-reference/action.md
+++ b/development/components/grid/columns-reference/action.md
@@ -27,7 +27,7 @@ $actionColumn = new ActionColumn('actions');
 $actionColumn->setName('Actions');
 $actionColumn->setOptions([
      'actions' => [
-        ->add((new LinkRowAction('delete'))
+        ((new LinkRowAction('delete'))
             ->setIcon('delete')
             ->setOptions([
                 'route' => 'admin_custom_route',

--- a/development/components/grid/columns-reference/action.md
+++ b/development/components/grid/columns-reference/action.md
@@ -22,12 +22,13 @@ For more info about possible actions see [Actions reference][actions-reference].
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 
 $actionColumn = new ActionColumn('actions');
 $actionColumn->setName('Actions');
 $actionColumn->setOptions([
-     'actions' => [
-        ((new LinkRowAction('delete'))
+     'actions' => (new RowActionCollection())
+        ->add((new LinkRowAction('delete'))
             ->setIcon('delete')
             ->setOptions([
                 'route' => 'admin_custom_route',


### PR DESCRIPTION
The 'actions' option expects a RowActionCollection object rather than an array.