### PR TITLE
The Mermaid graph in the ObjectModel documentation is too small to read

### DIFF
--- a/development/components/database/objectmodel.md
+++ b/development/components/database/objectmodel.md
@@ -542,7 +542,7 @@ $cmsIdsToDelete = [1, 2, 3, 8, 10];
 Thanks to the hooks, you can alter the Object Model or execute functions during the lifecycle of your models. Every hook receive an instance of the manipulated object model:
 
 <div class="mermaid">
-graph TD
+graph BT
    subgraph "DELETE"
         deleteA(actionObject<strong>DeleteBefore</strong>) --> deleteB(actionObject<i>Classname</i><strong>DeleteBefore</strong>) --> deleteC(actionObject<strong>DeleteAfter</strong>) --> deleteD(actionObject<i>Classname</i><strong>DeleteAfter</strong>)
     end


### PR DESCRIPTION
`BT` to improve readability

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | The mermaid graph at [ObjectModel lifecycle and hooks](https://devdocs.prestashop-project.org/9/development/components/database/objectmodel/#delete-multiple-entities) is too small to read
| Reason               |  `graph TD`
| Fix                       |  direction of the  graph from `TD` to `BT` to make it relayout in 3 stacks


- Before:
<img width="1116" height="223" alt="Screenshot 2025-12-26 at 16 19 39" src="https://github.com/user-attachments/assets/4476b930-3ce9-4734-bab3-cf5db4d6b1da" />

- After:
<img width="1105" height="623" alt="Screenshot 2025-12-26 at 16 19 26" src="https://github.com/user-attachments/assets/f968aa25-9e69-4c25-ada8-615028b375d4" />

