### PR TITLE
Fix link to DemoProductForm example module

### DIFF
--- a/development/components/form/_index.md
+++ b/development/components/form/_index.md
@@ -141,7 +141,7 @@ graph
 
 A `FormModifier` (also known as `FormBuilderModifier`) allows you to alter the contents of a Form. It is particularly useful within modules, allowing developers to add, modify, or remove elements from the form as required.
 
-It's been implemented in an example module: [DemoProductForm2](https://github.com/PrestaShop/example-modules/blob/master/demoproductform2/src/Form/Modifier/ProductFormModifier.php).
+It's been implemented in an example module: [DemoProductForm](https://github.com/PrestaShop/example-modules/blob/master/demoproductform/src/Form/Modifier/ProductFormModifier.php).
 
 ```php
 namespace PrestaShop\Module\DemoProductForm\Form\Modifier;


### PR DESCRIPTION
demoproductform2 not longer exists

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.x
| Description?      | demoproductform2 no longer exists
| Fixed ticket?     | 
| Sponsor company   | Creabilis.com

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
