### PR TITLE
Fix description for 'identifier' key in helperOptions

### DIFF
--- a/development/components/helpers/helperoptions.md
+++ b/development/components/helpers/helperoptions.md
@@ -36,7 +36,7 @@ $this->fields_options = [
         'autoload_rte' => 'true'                                 // Display a TinyMCE editor for textarea field only
         'suffix' => 'kg',                                        // Display after the field (ie. currency).
                                                                  // For text fields or password fields only.
-        'identifier' => 'id_carrier',                            // The unique ID for the form.
+        'identifier' => 'id_carrier',                            // The column name of the id in list rows.
         'list' => [list do display as options],             // For select field only.
         'empty_message' => $this->module->l('Display if list is empty'), // For select field only
         'cols' => 40,                                            // For textarea fields only.


### PR DESCRIPTION
Clarified the comment for the 'identifier' key

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | fix identifier description in helperOptions
| Sponsor company   | Creabilis.com

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
