### PR TITLE
Add actionUpdateDefaultCombinationAfter hook

### DIFF
--- a/modules/concepts/hooks/list-of-hooks/actionUpdateDefaultCombinationAfter.md
+++ b/modules/concepts/hooks/list-of-hooks/actionUpdateDefaultCombinationAfter.md
@@ -1,0 +1,63 @@
+---
+Title: actionUpdateDefaultCombinationAfter
+hidden: true
+hookTitle: 'React after a product default combination is updated'
+files:
+    -
+        url: 'https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/Adapter/Product/Combination/Update/DefaultCombinationUpdater.php'
+        file: src/Adapter/Product/Combination/Update/DefaultCombinationUpdater.php
+locations:
+    - 'back office'
+type: action
+hookAliases:
+array_return: false
+check_exceptions: false
+chain: false
+origin: core
+description: 'This hook is triggered after a product default combination is set (updated in database), allowing modules to react to the new default combination.'
+---
+
+{{% hookDescriptor %}}
+
+## Purpose
+
+The `actionUpdateDefaultCombinationAfter` hook allows modules to **react right after** the default combination of a product has been updated.
+
+It is dispatched when a merchant sets a new default combination in the product page (Back Office).
+
+## Parameters available
+
+The hook receives an array of parameters:
+
+| Parameter            | Type | Description |
+|---------------------|------|-------------|
+| id_product          | int  | The product ID. |
+| id_product_attribute| int  | The ID of the new default combination (product attribute ID). |
+
+## Example usage
+
+```php
+public function hookActionUpdateDefaultCombinationAfter(array $params): void
+{
+    $productId = (int) ($params['id_product'] ?? 0);
+    $productAttributeId = (int) ($params['id_product_attribute'] ?? 0);
+
+    if ($productId <= 0 || $productAttributeId <= 0) {
+        return;
+    }
+
+    // Your custom code
+}
+```
+
+## Call of the Hook in the origin file
+
+```php
+$this->hookDispatcher->dispatchWithParameters(
+    'actionUpdateDefaultCombinationAfter',
+    [
+        'id_product' => (int) $newDefaultCombination->id_product,
+        'id_product_attribute' => (int) $defaultCombinationId->getValue(),
+    ]
+);
+```

--- a/modules/concepts/hooks/list-of-hooks/actionUpdateDefaultCombinationAfter.md
+++ b/modules/concepts/hooks/list-of-hooks/actionUpdateDefaultCombinationAfter.md
@@ -30,9 +30,10 @@ It is dispatched when a merchant sets a new default combination in the product p
 The hook receives an array of parameters:
 
 | Parameter            | Type | Description |
-|---------------------|------|-------------|
-| id_product          | int  | The product ID. |
-| id_product_attribute| int  | The ID of the new default combination (product attribute ID). |
+|--------------------- |------|-------------|
+| id_product           | int  | The product ID. |
+| id_product_attribute | int  | The ID of the new default combination (product attribute ID). |
+| id_shop              | int  | The shop ID (current shop context). |
 
 ## Example usage
 
@@ -41,6 +42,7 @@ public function hookActionUpdateDefaultCombinationAfter(array $params): void
 {
     $productId = (int) ($params['id_product'] ?? 0);
     $productAttributeId = (int) ($params['id_product_attribute'] ?? 0);
+    $shopId = (int) ($params['id_shop'] ?? 0);
 
     if ($productId <= 0 || $productAttributeId <= 0) {
         return;
@@ -58,6 +60,7 @@ $this->hookDispatcher->dispatchWithParameters(
     [
         'id_product' => (int) $newDefaultCombination->id_product,
         'id_product_attribute' => (int) $defaultCombinationId->getValue(),
+        'id_shop' => $shopConstraint->getShopId()->getValue(),
     ]
 );
 ```

--- a/modules/concepts/hooks/list-of-hooks/actionUpdateDefaultCombinationAfter.md
+++ b/modules/concepts/hooks/list-of-hooks/actionUpdateDefaultCombinationAfter.md
@@ -29,11 +29,11 @@ It is dispatched when a merchant sets a new default combination in the product p
 
 The hook receives an array of parameters:
 
-| Parameter            | Type | Description |
-|--------------------- |------|-------------|
-| id_product           | int  | The product ID. |
-| id_product_attribute | int  | The ID of the new default combination (product attribute ID). |
-| id_shop              | int  | The shop ID (current shop context). |
+| Parameter            | Type      | Description |
+|--------------------- |-----------|-------------|
+| id_product           | int       | The product ID. |
+| id_product_attribute | int       | The ID of the new default combination (product attribute ID). |
+| id_shop              | int\|null | The shop ID when in **single shop context**, otherwise `null`. |
 
 ## Example usage
 
@@ -42,7 +42,9 @@ public function hookActionUpdateDefaultCombinationAfter(array $params): void
 {
     $productId = (int) ($params['id_product'] ?? 0);
     $productAttributeId = (int) ($params['id_product_attribute'] ?? 0);
-    $shopId = (int) ($params['id_shop'] ?? 0);
+
+    // id_shop can be null when not in a single shop context
+    $shopId = $params['id_shop'] ?? null;
 
     if ($productId <= 0 || $productAttributeId <= 0) {
         return;
@@ -60,7 +62,9 @@ $this->hookDispatcher->dispatchWithParameters(
     [
         'id_product' => (int) $newDefaultCombination->id_product,
         'id_product_attribute' => (int) $defaultCombinationId->getValue(),
-        'id_shop' => $shopConstraint->getShopId()->getValue(),
+        'id_shop' => $shopConstraint->isSingleShopContext()
+            ? $shopConstraint->getShopId()->getValue()
+            : null,
     ]
 );
 ```


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.x
| Description?      | This PR adds documentation for the `actionUpdateDefaultCombinationAfter` hook
| Related PR     | https://github.com/PrestaShop/PrestaShop/pull/40720
| Sponsor company   | Codencode snc
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
