### PR TITLE
Fix phpMyAdmin service in Docker configuration

### DIFF
--- a/basics/installation/environments/docker.md
+++ b/basics/installation/environments/docker.md
@@ -351,6 +351,8 @@ services:
       restart: unless-stopped
       ports:
         - 8081:80
+      networks:
+        - prestashop_network
 ```
 
 And access `http://localhost:8081` to access `phpMyAdmin`.


### PR DESCRIPTION
phpMyAdmin service has to be on the same network with MySQL server.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | I submitted a fix for phpMyAdmin service in the Docker configuration for PrestaShop 9.x.
| Fixed ticket?     | -
| Sponsor company   | Sleed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
