### PR TITLE
Fix URI template for attribute group endpoint

### DIFF
--- a/admin-api/contribute-to-core-api.md
+++ b/admin-api/contribute-to-core-api.md
@@ -251,7 +251,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 
 #[ApiResource(
     operations: [
-        // GET /attributes/group/{attributeGroupId}
+        // GET /attributes/groups/{attributeGroupId}
         new CQRSGet(
             uriTemplate: '/attributes/groups/{attributeGroupId}',
             requirements: ['attributeGroupId' => '\d+'],

--- a/admin-api/contribute-to-core-api.md
+++ b/admin-api/contribute-to-core-api.md
@@ -253,7 +253,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
     operations: [
         // GET /attributes/group/{attributeGroupId}
         new CQRSGet(
-            uriTemplate: '/attributes/group/{attributeGroupId}',
+            uriTemplate: '/attributes/groups/{attributeGroupId}',
             requirements: ['attributeGroupId' => '\d+'],
             CQRSQuery: GetAttributeGroupForEditing::class,
             scopes: ['attribute_group_read']


### PR DESCRIPTION
Following ADR, it should be plural form (attributes/goups), not attributes/group


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.x
| Description?      | Following ADR, it should be plural form (attributes/goups), not attributes/group
| Sponsor company   | axel-paillaud
