### PR TITLE
Update URL to point to version 8.0.0

### DIFF
--- a/modules/concepts/hooks/list-of-hooks/displayCarrierExtraContent.md
+++ b/modules/concepts/hooks/list-of-hooks/displayCarrierExtraContent.md
@@ -4,7 +4,7 @@ hidden: true
 hookTitle: 'Display additional content for a carrier (e.g pickup points)'
 files:
     -
-        url: 'https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/checkout/DeliveryOptionsFinder.php'
+        url: 'https://github.com/PrestaShop/PrestaShop/blob/8.0.0/classes/checkout/DeliveryOptionsFinder.php'
         file: classes/checkout/DeliveryOptionsFinder.php
 locations:
     - 'front office'

--- a/modules/concepts/hooks/list-of-hooks/displayCarrierExtraContent.md
+++ b/modules/concepts/hooks/list-of-hooks/displayCarrierExtraContent.md
@@ -4,7 +4,7 @@ hidden: true
 hookTitle: 'Display additional content for a carrier (e.g pickup points)'
 files:
     -
-        url: 'https://github.com/PrestaShop/PrestaShop/blob/8.0.0/classes/checkout/DeliveryOptionsFinder.php'
+        url: 'https://github.com/PrestaShop/PrestaShop/blob/9.0.x/classes/checkout/DeliveryOptionsFinder.php'
         file: classes/checkout/DeliveryOptionsFinder.php
 locations:
     - 'front office'


### PR DESCRIPTION
Branch 8.0.x doesn't exist anymore, use tag branch instead

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.x
| Description?      | Branch 8.0.x doesn't exist anymore, use tag branch instead
| Sponsor company   |axel-paillaud
