### PR TITLE
Admin API: Fix expected route name in bulk conventions

### DIFF
--- a/admin-api/contribute-to-core-api.md
+++ b/admin-api/contribute-to-core-api.md
@@ -479,7 +479,7 @@ For bulk action we create a new dedicated resource with only one array field `$a
 
 {{% notice warning %}}
 **ADR Bulk Operations Convention**:
-- Use `bulk-` prefix for the action in the URI (e.g., `/attributes/groups/delete`, not `/attributes/groups/bulk-delete`)
+- Use `bulk-` prefix for the action in the URI (e.g., `/attributes/groups/bulk-delete`, not `/attributes/groups/delete`)
 - Use plural domain name + "Ids" for parameter names (e.g., `attributeGroupIds`)
 - The example uses `PUT` method, but you could also use `DELETE` method depending on the operation
 {{% /notice %}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | The example in the convensions of bulk actions in the API was wrong. This PR fixes it.
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
