### PR TITLE
Change getProtectedEndpoints to static method

### DIFF
--- a/admin-api/contribute-to-core-api.md
+++ b/admin-api/contribute-to-core-api.md
@@ -919,7 +919,7 @@ class AttributeGroupEndpointTest extends ApiTestCase
         ]);
     }
 
-    public function getProtectedEndpoints(): iterable
+    public static function getProtectedEndpoints(): iterable
     {
         yield 'get endpoint' => [
             'GET',


### PR DESCRIPTION
PsApiResourcesTest\Integration\ApiPlatform\ApiTestCase::getProtectedEndpoints() want a static function, otherwise, we have a fatal error

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | PsApiResourcesTest\Integration\ApiPlatform\ApiTestCase::getProtectedEndpoints() want a static function, otherwise, we have a fatal error
| Sponsor company   | axel-paillaud
