### PR TITLE
Fix syntax error in tutorial.md

### DIFF
--- a/modules/creation/tutorial.md
+++ b/modules/creation/tutorial.md
@@ -83,7 +83,7 @@ class MyModule extends Module
         $this->need_instance = 0;
         $this->ps_versions_compliancy = [
             'min' => '8.0.0',
-            'max' => '9.99.99,
+            'max' => '9.99.99',
         ];
         $this->bootstrap = true;
 


### PR DESCRIPTION
Missing closing quote in ps_versions_compliancy 'max' value.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | Fixes a syntax error in the documentation example. The 'max' value in ps_versions_compliancy was missing a closing quote, making the PHP snippet invalid.
| Fixed ticket?     | N/A
| Sponsor company   | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
