### PR TITLE
Update theme name description in installation guide

### DIFF
--- a/basics/installation/advanced/install-from-cli.md
+++ b/basics/installation/advanced/install-from-cli.md
@@ -52,10 +52,10 @@ This command, by default, will display the various available options:
 | `password`      | Admin user password                        | Correct Horse Battery Staple | _string_                                                                                              |
 | `email`         | Admin user email                           | pub@prestashop.com           | _string_                                                                                              |
 | `license`       | Show PrestaShop license after installation | 0                            | 0, 1                                                                                                  |
-| `theme`         | Theme name to install                      | "" (classic)                 | Theme name (located in `/themes`)                                                                     |
+| `theme`         | Theme name to install                      | "" (classic, hummingbird since 9.1.0)    | Theme name (located in `/themes`)                                                         |
 | `ssl`           | Enable SSL (from PS 1.7.4)                 | 0                            | 0, 1                                                                                                  |
 | `rewrite`       | Enable rewrite engine                      | 1                            | 0, 1                                                                                                  |
-| `fixtures`      | Install fixtures. Equivalent of "*Installation of demo products*" in the GUI. | 1                            | 0, 1                                                                                                  |
+| `fixtures`      | Install fixtures. Equivalent of "*Installation of demo products*" in the GUI. | 1                            | 0, 1                                                               |
 | `modules`       | Modules to install, separated by comma     | [] (all)                     | _array_ of module names (located in `/modules`)                                                       |
 
 - All the options from the regular in-browser installer are available, with their default values listed above.


### PR DESCRIPTION
Updated default theme name to include 'hummingbird' since version 9.1.0.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | Default theme in install (CLI) is not classic since 9.1.0.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
