### PR TITLE
Pin line-anchored GitHub links to the 9.1.0 tag

### DIFF
--- a/development/components/database/objectmodel.md
+++ b/development/components/database/objectmodel.md
@@ -166,7 +166,7 @@ Field type is an important setting, it determines how ObjectModel will format yo
 #### Validation rules reference
 
 Several validation rules are available for your ObjectModel fields.
-[Please refer to the Validate class of PrestaShop](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/Validate.php) for a complete list.
+[Please refer to the Validate class of PrestaShop](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/classes/Validate.php) for a complete list.
 
 ### Add timestamps to your entity (date_add and date_upd)
 
@@ -208,7 +208,7 @@ $cms->save();
 
 In this example, we create an entity from scratch. Then, we set its `position` attribute, and we call the `save()` method. The `save()` method will trigger the `add()` method since its `id` attribute is not yet known (because the entity is not created in database).
 
-If the insert is successful, the ObjectModel class will set the entity's id (retrieved from the database). [Complete reference here](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/ObjectModel.php#L572-L658).
+If the insert is successful, the ObjectModel class will set the entity's id (retrieved from the database). [Complete reference here](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/ObjectModel.php#L483-L576).
 
 
 ### Load and save an object
@@ -221,7 +221,7 @@ $cms->position = 3;
 $cms->save();
 ```
 
-In this example, we retrieve an entity from the database with its id. Then, we change its `position` attribute and call the same `save()` method. The `save()` method will trigger the `update()` method and not the `add()` method since its `id` attribute is known. [Complete reference here](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/ObjectModel.php#L750-L868).
+In this example, we retrieve an entity from the database with its id. Then, we change its `position` attribute and call the same `save()` method. The `save()` method will trigger the `update()` method and not the `add()` method since its `id` attribute is known. [Complete reference here](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/ObjectModel.php#L671-L750).
 
 ### Hard or soft delete an object
 
@@ -572,7 +572,7 @@ public function hookActionObjectProductDeleteAfter(Product $product)
 
 Here is the reference of the methods described on this page. Many other methods that we don't described here are available.
 
-See complete implementation here : [ObjectModel.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/ObjectModel.php)
+See complete implementation here : [ObjectModel.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/classes/ObjectModel.php)
 
 ```php
 /**

--- a/development/components/form/types-reference/amount-currency.md
+++ b/development/components/form/types-reference/amount-currency.md
@@ -7,7 +7,7 @@ title: AmountCurrencyType
 Amount with currency: combination of a `NumberType` input and a `ChoiceType` input (for currency selection).
 
 - Namespace: `PrestaShopBundle\Form\Admin\Type`
-- Reference: [AmountCurrencyType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/AmountCurrencyType.php)
+- Reference: [AmountCurrencyType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/AmountCurrencyType.php)
 
 ## Type options
 
@@ -20,7 +20,7 @@ Amount with currency: combination of a `NumberType` input and a `ChoiceType` inp
 
 ## Code example
 
-- [OrderPaymentType.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderPaymentType.php#L113-L122)
+- [OrderPaymentType.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderPaymentType.php#L93-L106)
 
 ```php
 $builder

--- a/development/components/form/types-reference/button-collection.md
+++ b/development/components/form/types-reference/button-collection.md
@@ -7,7 +7,7 @@ title: ButtonCollectionType
 `ButtonCollectionType` is a form type used to group buttons in a common form group, which is useful for forms that have multiple submit buttons.
 
 - Namespace: `PrestaShopBundle\Form\Admin\Type`
-- Reference: [ButtonCollectionType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php)
+- Reference: [ButtonCollectionType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php)
 
 ## Type options
 
@@ -20,7 +20,7 @@ title: ButtonCollectionType
 
 ## Code example
 
-- [CombinationItemType.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationItemType.php#L150-L183)
+- [CombinationItemType.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationItemType.php#L128-L222)
 
 ```php
 $builder->add('actions', ButtonCollectionType::class, [
@@ -28,6 +28,7 @@ $builder->add('actions', ButtonCollectionType::class, [
         'edit' => [
             'type' => IconButtonType::class,
             'options' => [
+                'label' => $this->trans('Edit', 'Admin.Actions'),
                 'icon' => 'mode_edit',
                 'attr' => [
                     'class' => 'edit-combination-item tooltip-link',
@@ -39,6 +40,7 @@ $builder->add('actions', ButtonCollectionType::class, [
         'delete' => [
             'type' => IconButtonType::class,
             'options' => [
+                'label' => $this->trans('Delete', 'Admin.Actions'),
                 'icon' => 'delete',
                 'attr' => [
                     'class' => 'delete-combination-item tooltip-link',
@@ -48,6 +50,7 @@ $builder->add('actions', ButtonCollectionType::class, [
                     'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
                     'data-toggle' => 'pstooltip',
                     'data-original-title' => $this->trans('Delete', 'Admin.Actions'),
+                    'data-shop-id' => $this->contextShopId,
                 ],
             ],
         ],
@@ -56,6 +59,8 @@ $builder->add('actions', ButtonCollectionType::class, [
     'attr' => [
         'class' => 'combination-row-actions',
     ],
+    'inline_buttons_limit' => self::INLINE_ACTIONS_LIMIT,
+    'use_inline_labels' => false,
 ])
 ```
 

--- a/development/components/form/types-reference/color-picker-type.md
+++ b/development/components/form/types-reference/color-picker-type.md
@@ -7,7 +7,7 @@ title: ColorPickerType
 This form class is responsible for creating a color picker field
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [ColorPickerType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/ColorPickerType.php)
+- Reference: [ColorPickerType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/ColorPickerType.php)
 
 ## Type options
 
@@ -16,11 +16,13 @@ This form class is responsible for creating a color picker field
 
 ## Code example
 
-- [OrderStateType.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php#L132-L134)
+- [OrderStateType.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php#L158-L162)
 
 ```php
 $builder->add('color', ColorPickerType::class, [
-    'required' => true,
+    'required' => false,
+    'label' => $this->trans('Color', 'Admin.Shopparameters.Feature'),
+    'help' => $this->trans('Background color of this status label. Used both in backoffice and on order tracking page. HTML colors only.', 'Admin.Shopparameters.Help'),
 ])
 ```
 

--- a/development/components/form/types-reference/configurable-country-choice-type.md
+++ b/development/components/form/types-reference/configurable-country-choice-type.md
@@ -7,7 +7,7 @@ title: ConfigurableCountryChoiceType
 Class responsible for providing configurable countries list
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [ConfigurableCountryChoiceType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/ConfigurableCountryChoiceType.php)
+- Reference: [ConfigurableCountryChoiceType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/ConfigurableCountryChoiceType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ Class responsible for providing configurable countries list
 
 ## Code example
 
-- [StateGridDefinitionFactory.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Core/Grid/Definition/Factory/StateGridDefinitionFactory.php#L210-L218)
+- [StateGridDefinitionFactory.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/Core/Grid/Definition/Factory/StateGridDefinitionFactory.php#L191-L199)
 
 ```php
 $builder->add(

--- a/development/components/form/types-reference/custom-content-type.md
+++ b/development/components/form/types-reference/custom-content-type.md
@@ -7,7 +7,7 @@ title: CustomContentType
 Type is used to add any content at any position of the form, rather than the actual field.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [CustomContentType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/CustomContentType.php)
+- Reference: [CustomContentType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/CustomContentType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ Type is used to add any content at any position of the form, rather than the act
 
 ## Code example
 
-- [CmsPageType.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php#L142-L149)
+- [CmsPageType.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php#L120-L130)
 
 ```php
 $builder->add('seo_preview', CustomContentType::class, [
@@ -25,6 +25,9 @@ $builder->add('seo_preview', CustomContentType::class, [
     'template' => '@PrestaShop/Admin/Improve/Design/Cms/Blocks/seo_preview.html.twig',
     'data' => [
         'cms_url' => $options['cms_preview_url'],
+    ],
+    'row_attr' => [
+        'class' => 'seo_preview',
     ],
 ])
 ```

--- a/development/components/form/types-reference/delta-quantity-type.md
+++ b/development/components/form/types-reference/delta-quantity-type.md
@@ -7,7 +7,7 @@ title: DeltaQuantityType
 Quantity field that displays the initial quantity (not editable) and allows editing with delta quantity instead (ex: +5, -8). The input data of this form type is the initial (as a plain integer) however, its output on submit is the delta quantity.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [DeltaQuantityType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php)
+- Reference: [DeltaQuantityType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ Quantity field that displays the initial quantity (not editable) and allows edit
 
 ## Code example
 
-- [BulkCombinationStockType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php#L78-L86)
+- [BulkCombinationStockType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php#L52-L61)
 
 ```php
 $builder->add('delta_quantity', DeltaQuantityType::class, [
@@ -27,6 +27,7 @@ $builder->add('delta_quantity', DeltaQuantityType::class, [
     'disabled_value' => function (?array $data) {
         return empty($data['quantity']) && empty($data['delta']);
     },
+    'modify_all_shops' => true,
 ])
 ```
 

--- a/development/components/form/types-reference/email-type.md
+++ b/development/components/form/types-reference/email-type.md
@@ -20,15 +20,15 @@ Symfony native EmailType extended with IDNConverter (InternationalizedDomainName
 
 ```php
 $builder->add('email', EmailType::class, [
-                'label' => $this->trans('Email address', [], 'Admin.Global'),
-                'constraints' => [
-                    $this->getNotBlankConstraint(),
-                    $this->getLengthConstraint(EmployeeEmail::MAX_LENGTH),
-                    new Email([
-                        'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
-                    ]),
-                ],
-            ])
+    'label' => $this->trans('Email address', [], 'Admin.Global'),
+    'constraints' => [
+        $this->getNotBlankConstraint(),
+        $this->getLengthConstraint(EmployeeEmail::MAX_LENGTH),
+        new Email([
+            'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+        ]),
+    ],
+])
 ```
 
 ## Preview example

--- a/development/components/form/types-reference/email-type.md
+++ b/development/components/form/types-reference/email-type.md
@@ -7,7 +7,7 @@ title: EmailType
 Symfony native EmailType extended with IDNConverter (InternationalizedDomainNameConverter) feature
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [EmailType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/EmailType.php)
+- Reference: [EmailType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/EmailType.php)
 
 ## Type options
 
@@ -16,18 +16,19 @@ Symfony native EmailType extended with IDNConverter (InternationalizedDomainName
 
 ## Code example
 
-- [EmployeeType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php#L136-L144)
+- [EmployeeType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php#L140-L149)
 
 ```php
 $builder->add('email', EmailType::class, [
-    'constraints' => [
-        $this->getNotBlankConstraint(),
-        $this->getLengthConstraint(EmployeeEmail::MAX_LENGTH),
-        new Email([
-            'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
-        ]),
-    ],
-])
+                'label' => $this->trans('Email address', [], 'Admin.Global'),
+                'constraints' => [
+                    $this->getNotBlankConstraint(),
+                    $this->getLengthConstraint(EmployeeEmail::MAX_LENGTH),
+                    new Email([
+                        'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                    ]),
+                ],
+            ])
 ```
 
 ## Preview example

--- a/development/components/form/types-reference/entity-search-input-type.md
+++ b/development/components/form/types-reference/entity-search-input-type.md
@@ -41,6 +41,7 @@ $builder
         'label' => false,
         'remote_url' => $this->router->generate('admin_categories_get_ajax_categories', ['query' => '__QUERY__']),
         'placeholder' => $this->trans('To which category should the page redirect?', 'Admin.Catalog.Help'),
+        'help' => $this->trans('By default, the closest active parent category will be used if no category is selected.', 'Admin.Catalog.Help'),
         'filtered_identities' => [$options['id_category'], $this->homeCategoryId],
     ]);
 ```

--- a/development/components/form/types-reference/entity-search-input-type.md
+++ b/development/components/form/types-reference/entity-search-input-type.md
@@ -61,7 +61,7 @@ let searchInput = new window.prestashop.component.EntitySearchInput(elementId, {
       console.log('Event on product deletion');
     },
     onSelectedContent: () => {
-      console.log("Event on product selection");
+      console.log('Event on product selection');
     },
 });
 ```

--- a/development/components/form/types-reference/entity-search-input-type.md
+++ b/development/components/form/types-reference/entity-search-input-type.md
@@ -58,7 +58,7 @@ const elementId = $("#form_prefix_field_name");
 
 let searchInput = new window.prestashop.component.EntitySearchInput(elementId, {
     onRemovedContent: () => {
-      console.log("Event on product deletion");
+      console.log('Event on product deletion');
     },
     onSelectedContent: () => {
       console.log("Event on product selection");

--- a/development/components/form/types-reference/entity-search-input-type.md
+++ b/development/components/form/types-reference/entity-search-input-type.md
@@ -7,7 +7,7 @@ title: EntitySearchInputType
 This form type is used for an OneToMany (or ManyToMany) association, it allows to search a list of entities (based on a remote URL) and associate it. It is based on the CollectionType form type which provides prototype features to display a custom template for each associated item.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [EntitySearchInputType](https://github.com/PrestaShop/PrestaShop/blob/9.0.x/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php)
+- Reference: [EntitySearchInputType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php)
 
 ## Type options
 
@@ -30,7 +30,7 @@ Learn more about [JavaScript components and how to use them]({{<relref "/9/devel
 
 ## Code example
 
-- [RedirectOptionType](https://github.com/PrestaShop/PrestaShop/blob/9.0.x/src/PrestaShopBundle/Form/Admin/Sell/Category/SEO/RedirectOptionType.php#L86-L96)
+- [RedirectOptionType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/Category/SEO/RedirectOptionType.php#L66-L76)
 
 ```php
 $builder
@@ -41,7 +41,6 @@ $builder
         'label' => false,
         'remote_url' => $this->router->generate('admin_categories_get_ajax_categories', ['query' => '__QUERY__']),
         'placeholder' => $this->trans('To which category should the page redirect?', 'Admin.Catalog.Help'),
-        'help' => $this->trans('By default, the closest active parent category will be used if no category is selected.', 'Admin.Catalog.Help'),
         'filtered_identities' => [$options['id_category'], $this->homeCategoryId],
     ]);
 ```
@@ -59,11 +58,11 @@ const elementId = $("#form_prefix_field_name");
 
 let searchInput = new window.prestashop.component.EntitySearchInput(elementId, {
     onRemovedContent: () => {
-      console.log('Event on product deletion');
+      console.log("Event on product deletion");
     },
     onSelectedContent: () => {
-      console.log('Event on product selection');
-    }
+      console.log("Event on product selection");
+    },
 });
 ```
 

--- a/development/components/form/types-reference/icon-button-type.md
+++ b/development/components/form/types-reference/icon-button-type.md
@@ -7,7 +7,7 @@ title: IconButtonType
 A form button with material icon.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [IconButtonType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php)
+- Reference: [IconButtonType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/IconButtonType.php)
 
 ## Type options
 
@@ -18,18 +18,26 @@ A form button with material icon.
 
 ## Code example
 
-- [FooterType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php#L99-L107)
+- [FooterType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php#L102-L116)
 
 ```php
-$builder->add('catalog', IconButtonType::class, [
-    'label' => $this->trans('Go to catalog', 'Admin.Catalog.Feature'),
-    'type' => 'link',
-    'icon' => 'arrow_back_ios',
-    'attr' => [
-        'class' => 'btn-outline-secondary border-white go-to-catalog-button',
-        'href' => $this->router->generate('admin_products_v2_index', ['offset' => 'last', 'limit' => 'last']),
-    ],
-])
+        $builder
+            ->add('actions', ButtonCollectionType::class, [
+                'buttons' => [
+                    'catalog' => [
+                        'type' => IconButtonType::class,
+                        'options' => [
+                            'label' => $this->trans('Go to catalog', 'Admin.Catalog.Feature'),
+                            'type' => 'link',
+                            'icon' => 'arrow_back_ios',
+                            'attr' => [
+                                'class' => 'btn-outline-secondary go-to-catalog-button',
+                                'href' => $this->router->generate('admin_products_index', ['offset' => 'last', 'limit' => 'last']),
+                            ],
+                        ],
+                    ],
+                ],
+            ])
 ```
 
 ## Preview example

--- a/development/components/form/types-reference/icon-button-type.md
+++ b/development/components/form/types-reference/icon-button-type.md
@@ -21,23 +21,23 @@ A form button with material icon.
 - [FooterType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php#L102-L116)
 
 ```php
-        $builder
-            ->add('actions', ButtonCollectionType::class, [
-                'buttons' => [
-                    'catalog' => [
-                        'type' => IconButtonType::class,
-                        'options' => [
-                            'label' => $this->trans('Go to catalog', 'Admin.Catalog.Feature'),
-                            'type' => 'link',
-                            'icon' => 'arrow_back_ios',
-                            'attr' => [
-                                'class' => 'btn-outline-secondary go-to-catalog-button',
-                                'href' => $this->router->generate('admin_products_index', ['offset' => 'last', 'limit' => 'last']),
-                            ],
-                        ],
+$builder
+    ->add('actions', ButtonCollectionType::class, [
+        'buttons' => [
+            'catalog' => [
+                'type' => IconButtonType::class,
+                'options' => [
+                    'label' => $this->trans('Go to catalog', 'Admin.Catalog.Feature'),
+                    'type' => 'link',
+                    'icon' => 'arrow_back_ios',
+                    'attr' => [
+                        'class' => 'btn-outline-secondary go-to-catalog-button',
+                        'href' => $this->router->generate('admin_products_index', ['offset' => 'last', 'limit' => 'last']),
                     ],
                 ],
-            ])
+            ],
+        ],
+    ])
 ```
 
 ## Preview example

--- a/development/components/form/types-reference/image-preview-type.md
+++ b/development/components/form/types-reference/image-preview-type.md
@@ -7,7 +7,7 @@ title: ImagePreviewType
 This form type is used to display an image value without providing an interactive input to edit it. It is based on a hidden input so it could be changed programmatically, or used just to display an image in a form.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [ImagePreviewType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php)
+- Reference: [ImagePreviewType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/ImagePreviewType.php)
 
 ## Type options
 
@@ -18,7 +18,7 @@ This form type is used to display an image value without providing an interactiv
 
 ## Code example
 
-- [HeaderType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php#L79-L81)
+- [HeaderType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php#L70-L72)
 
 ```php
 $builder->add('cover_thumbnail', ImagePreviewType::class, [

--- a/development/components/form/types-reference/log-severity-choice-type.md
+++ b/development/components/form/types-reference/log-severity-choice-type.md
@@ -7,7 +7,7 @@ title: LogSeverityChoiceType
 ChoiceType of PrestaShopLogger Log levels
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [LogSeverityChoiceType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/LogSeverityChoiceType.php)
+- Reference: [LogSeverityChoiceType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/LogSeverityChoiceType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ ChoiceType of PrestaShopLogger Log levels
 
 ## Code example
 
-- [LogsByEmailType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php#L46-L59)
+- [LogsByEmailType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php#L25-L39)
 
 ```php
 $builder->add('logs_by_email', LogSeverityChoiceType::class, [

--- a/development/components/form/types-reference/price-reduction-type.md
+++ b/development/components/form/types-reference/price-reduction-type.md
@@ -7,7 +7,7 @@ title: PriceReductionType
 Responsible for creating form for price reduction
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [PriceReductionType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/PriceReductionType.php)
+- Reference: [PriceReductionType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/PriceReductionType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ Responsible for creating form for price reduction
 
 ## Code example
 
-- [CatalogPriceRuleType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php#L190-L205)
+- [CatalogPriceRuleType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php#L136-L151)
 
 ```php
 $builder->add('reduction', PriceReductionType::class, [

--- a/development/components/form/types-reference/profile-choice-type.md
+++ b/development/components/form/types-reference/profile-choice-type.md
@@ -7,7 +7,7 @@ title: ProfileChoiceType
 Class ProfileChoiceType is choice type for selecting employee's profile.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type\Common\Team
-- Reference: [ProfileChoiceType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/Common/Team/ProfileChoiceType.php)
+- Reference: [ProfileChoiceType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/Common/Team/ProfileChoiceType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ Class ProfileChoiceType is choice type for selecting employee's profile.
 
 ## Code example
 
-- [EmployeeGridDefinitionFactory](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Core/Grid/Definition/Factory/EmployeeGridDefinitionFactory.php#L203-L209)
+- [EmployeeGridDefinitionFactory](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/Core/Grid/Definition/Factory/EmployeeGridDefinitionFactory.php#L183-L189)
 
 ```php
 ->add(

--- a/development/components/form/types-reference/radio-with-choice-children-type.md
+++ b/development/components/form/types-reference/radio-with-choice-children-type.md
@@ -7,7 +7,7 @@ title: RadioWithChoiceChildrenType
 Combination of a RadioType and a ChoiceType fields
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [RadioWithChoiceChildrenType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/RadioWithChoiceChildrenType.php)
+- Reference: [RadioWithChoiceChildrenType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/RadioWithChoiceChildrenType.php)
 
 ## Type options
 
@@ -19,7 +19,7 @@ Combination of a RadioType and a ChoiceType fields
 
 ## Code example
 
-- [ExportCataloguesType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportCataloguesType.php#L106-L118)
+- [ExportCataloguesType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportCataloguesType.php#L77-L89)
 
 ```php
 $builder->add('themes_selectors', RadioWithChoiceChildrenType::class, [
@@ -30,7 +30,7 @@ $builder->add('themes_selectors', RadioWithChoiceChildrenType::class, [
     'child_choice' => [
         'name' => 'selected_value',
         'empty' => $this->trans('Select a theme', 'Admin.International.Feature'),
-        'choices' => $this->excludeDefaultThemeFromChoices($this->themeChoices),
+        'choices' => $this->excludeCoreThemesFromChoices($this->themeChoices),
         'label' => false,
         'multiple' => false,
     ],

--- a/development/components/form/types-reference/search-and-reset-type.md
+++ b/development/components/form/types-reference/search-and-reset-type.md
@@ -7,7 +7,7 @@ title: SearchAndResetType
 FormType used in rendering of "Search and Reset" action in Grids.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [SearchAndResetType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php)
+- Reference: [SearchAndResetType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ FormType used in rendering of "Search and Reset" action in Grids.
 
 ## Code example
 
-- [AddressGridDefinitionFactory](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php#L238-L248)
+- [AddressGridDefinitionFactory](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php#L219-L229)
 
 ```php
 ->add(

--- a/development/components/form/types-reference/shop-restriction-checkbox-type.md
+++ b/development/components/form/types-reference/shop-restriction-checkbox-type.md
@@ -7,7 +7,7 @@ title: ShopRestrictionCheckboxType
 This class displays customized checkbox which is used for shop restriction functionality.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [ShopRestrictionCheckboxType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/ShopRestrictionCheckboxType.php)
+- Reference: [ShopRestrictionCheckboxType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/ShopRestrictionCheckboxType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ This class displays customized checkbox which is used for shop restriction funct
 
 ## Code example
 
-- [ShopLogosType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosType.php#L132-L137)
+- [ShopLogosType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosType.php#L112-L117)
 
 ```php
 $builder->add($form->getName() . $suffix, ShopRestrictionCheckboxType::class, [

--- a/development/components/form/types-reference/text-preview-type.md
+++ b/development/components/form/types-reference/text-preview-type.md
@@ -7,7 +7,7 @@ title: TextPreviewType
 This form type displays a text value without providing an interactive input to edit it. It is based on a hidden input so it could be changed programmatically, or used just to display data in a form.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [TextPreviewType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php)
+- Reference: [TextPreviewType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php)
 
 ## Type options
 
@@ -20,7 +20,7 @@ This form type displays a text value without providing an interactive input to e
 
 ## Code example
 
-- [SearchedCustomerType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php#L50-L53)
+- [SearchedCustomerType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php#L26-L28)
 
 ```php
 $builder->add('fullname_and_email', TextPreviewType::class, [

--- a/development/components/form/types-reference/translatable-choice-type.md
+++ b/development/components/form/types-reference/translatable-choice-type.md
@@ -7,7 +7,7 @@ title: TranslatableChoiceType
 Class TranslatableChoiceType adds translatable choice types with custom inner type to forms. Language selection uses a dropdown.
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [TranslatableChoiceType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php)
+- Reference: [TranslatableChoiceType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php)
 
 ## Type options
 
@@ -16,17 +16,22 @@ Class TranslatableChoiceType adds translatable choice types with custom inner ty
 
 ## Code example
 
-- [OrderStateType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php#L198-L207)
+- [OrderStateType](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php#L219-L233)
 
 ```php
 $builder->add('template', TranslatableChoiceType::class, [
-    'hint' => sprintf(
-        '%s<br>%s',
-        $this->trans('Only letters, numbers and underscores ("_") are allowed.', 'Admin.Shopparameters.Help'),
-        $this->trans('Email template for both .html and .txt.', 'Admin.Shopparameters.Help')
-    ),
+    'label' => $this->trans('Template', 'Admin.Shopparameters.Feature'),
+    'hint' => $this->trans('Select an email template that will be sent after setting this status.', 'Admin.Shopparameters.Help'),
     'required' => false,
     'choices' => $this->templates,
-    'row_attr' => $this->templateAttributes,
+    'row_attr' => $this->templateAttributes + [
+        'class' => 'order_state_template_select',
+    ],
+    'button' => [
+        'label' => $this->trans('Preview', 'Admin.Actions'),
+        'icon' => 'visibility',
+        'class' => 'btn btn-primary',
+        'id' => 'order_state_template_preview',
+    ],
 ])
 ```

--- a/development/components/form/types-reference/zone-choice-type.md
+++ b/development/components/form/types-reference/zone-choice-type.md
@@ -7,7 +7,7 @@ title: ZoneChoiceType
 Class is responsible for providing configurable zone choices with -- symbol in front of array
 
 - Namespace: PrestaShopBundle\Form\Admin\Type
-- Reference: [ZoneChoiceType](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/Form/Admin/Type/ZoneChoiceType.php)
+- Reference: [ZoneChoiceType](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/src/PrestaShopBundle/Form/Admin/Type/ZoneChoiceType.php)
 
 ## Type options
 
@@ -16,7 +16,7 @@ Class is responsible for providing configurable zone choices with -- symbol in f
 
 ## Code example
 
-- [StateGridDefinitionFactory](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Core/Grid/Definition/Factory/StateGridDefinitionFactory.php#L203-L209)
+- [StateGridDefinitionFactory](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/src/Core/Grid/Definition/Factory/StateGridDefinitionFactory.php#L184-L190)
 
 ```php
 return (new FilterCollection())

--- a/development/components/link.md
+++ b/development/components/link.md
@@ -20,7 +20,7 @@ The `Link` component generates URLs for various PrestaShop routes. It provides a
 - `getModuleLink()`
 - `getPageLink()`
 
-and many more. To discover all available methods, you can explore the [Link class](https://github.com/PrestaShop/PrestaShop/blob/8.1.x/classes/Link.php).
+and many more. To discover all available methods, you can explore the [Link class](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/classes/Link.php).
 
 {{% notice info %}}
 While possible, it is discouraged to instantiate the `Link` class by yourself. Please use the `Link` provided by a `Context`.
@@ -44,7 +44,7 @@ $product = new Product(123);
 $link = $context->link->getProductLink($product);
 ```
 
-More parameters are available for this method, please refer to the [method definition for details](https://github.com/PrestaShop/PrestaShop/blob/8.1.x/classes/Link.php#L122-L141).
+More parameters are available for this method, please refer to the [method definition for details](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/Link.php#L103-L122).
 
 ### Use the Link component to get the URL of a Category with getCategoryLink() method
 
@@ -58,7 +58,7 @@ $category = new Category(123);
 $link = $context->link->getCategoryLink($category);
 ```
 
-More parameters are available for this method, please refer to the [method definition for details](https://github.com/PrestaShop/PrestaShop/blob/8.1.x/classes/Link.php#L411-L422).
+More parameters are available for this method, please refer to the [method definition for details](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/Link.php#L405-L416).
 
 ### Use the Link component to get the URL of a Module front controller with getModuleLink() method
 
@@ -79,7 +79,7 @@ $params = [
 $link = $context->link->getModuleLink('mymodulename', 'controllerName', $params);
 ```
 
-More parameters are available for this method, please refer to the [method definition for details](https://github.com/PrestaShop/PrestaShop/blob/8.1.x/classes/Link.php#L670-L684).
+More parameters are available for this method, please refer to the [method definition for details](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/Link.php#L661-L673).
 
 ### Use the Link component to get the URL of a page with getPageLink() method
 
@@ -102,7 +102,7 @@ $params = [
 $link = $context->link->getPageLink('cart', true, null, $params,false);
 ```
 
-More parameters are available for this method, please refer to the [method definition for details](https://github.com/PrestaShop/PrestaShop/blob/8.1.x/classes/Link.php#L1109-L1121).
+More parameters are available for this method, please refer to the [method definition for details](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/Link.php#L1099-L1113).
 
 ### Generate URLs to admin routes using Link
 

--- a/development/components/smarty-extensions/_index.md
+++ b/development/components/smarty-extensions/_index.md
@@ -227,7 +227,7 @@ The `classname` data modifier will ensure that your string is a valid class name
 It will:
 
 1. Put it in lowercase.
-2. Replace any non-ASCII characters (such as accented characters) [with their ASCII equivalent with Transliterator](https://github.com/PrestaShop/PrestaShop/blob/8.0.0/classes/Tools.php#L1431-L1440). 
+2. Replace any non-ASCII characters (such as accented characters) [with their ASCII equivalent with Transliterator](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/Tools.php#L1275-L1278).
 3. Replace all non-alphanumerical characters with a single dash.
 4. Ensure only one consecutive dash is used.
 

--- a/development/orders-lifecycle/_index.md
+++ b/development/orders-lifecycle/_index.md
@@ -20,7 +20,7 @@ The Cart is created in database once first Product is being added into it.
 
 {{% notice note %}}
 When a Customer signs-in, has an empty Cart in its Cookie (or does not have a Cart) and has a previous non ordered Cart in its profile, the default behaviour of PrestaShop is to reload its most recent non ordered Cart. That behaviour can be adjusted in `Configure -> Shop parameters -> Customer settings`, the related setting is `PS_CART_FOLLOWING` : `Re-display cart at login`.
-This setting is implemented in: [Context.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/Context.php#L365).
+This setting is implemented in: [Context.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/Context.php#L304).
 {{% /notice %}}
 
 <div class='mermaid'>
@@ -74,7 +74,7 @@ Please note that if a Cart contains only Virtual Products, there is no `checkout
 3. **Select a shipping method** (checkout-delivery-step): after this step is complete, you will need to select one of the available Carriers
    (Carriers are searched by delivery address, sometimes the total weight of the Products, their prices, and information about the Customer (a group to which the Customer belongs) and can be modified by Shop Employees on Improve -> Shipping -> Carriers page).
    Note that the Carrier will not be available if a selected country or zone is disabled (in Back Office International -> Locations) or Carrier shipping and locations settings are not configured.
-3. **Select payment method** (checkout-payment-step): choose how to pay for the Order. Shop Employees can configure payment methods in
+4. **Select payment method** (checkout-payment-step): choose how to pay for the Order. Shop Employees can configure payment methods in
    Back Office `Payment -> Payment methods`.
    All payments are handled by payment modules. PrestaShop comes with 3 [payment modules]({{< relref "/9/modules/payment" >}}) by default:
 
@@ -86,7 +86,7 @@ Please note that if a Cart contains only Virtual Products, there is no `checkout
 You can restrict the availability of the payment methods in Front Office by currencies, countries, and groups and map them to Carriers (ship2pay). You can do that in Back Office `Improve -> Payment -> Preferences`.
    {{% /notice %}}
 
-4. **Submit Order**: Once the Order is submitted, a unique Order reference is generated, and certain records from a Cart and related
+5.  **Submit Order**: Once the Order is submitted, a unique Order reference is generated, and certain records from a Cart and related
    entities are added into following database tables:
     * `Orders`
     * `Order_history`
@@ -99,7 +99,7 @@ You can restrict the availability of the payment methods in Front Office by curr
 At this step, some important data is duplicated (in `Order_detail`) to ensure Product data will remain available in the Order even if the Product is deleted or modified afterward. Information about the prices is also duplicated to ensure the Order amount will remain immutable.
 {{% /notice %}}
 
-5. After Order is successfully created, an email with the Order information is sent to the Customer.
+6. After Order is successfully created, an email with the Order information is sent to the Customer.
 
 {{% notice note %}}
 Email sending settings can be found in Back Office `Configure -> Advanced parameters -> E-mail`. Email translations and templates
@@ -113,9 +113,9 @@ click `More actions -> Send pre-filled Order to the Customer by email` in summar
 {{% notice note %}}
 **Dive more in PrestaShop's Checkout process:**
 Learn how it works under the hood by looking at:
-- [classes/checkout/CheckoutSession.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/checkout/CheckoutSession.php)
-- [classes/checkout/CheckoutProcess.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/checkout/CheckoutProcess.php)
-- [classes/checkout/CheckoutStepInterface.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/checkout/CheckoutStepInterface.php)
+- [classes/checkout/CheckoutSession.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/classes/checkout/CheckoutSession.php)
+- [classes/checkout/CheckoutProcess.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/classes/checkout/CheckoutProcess.php)
+- [classes/checkout/CheckoutStepInterface.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.x/classes/checkout/CheckoutStepInterface.php)
 
 {{% /notice %}}
 

--- a/themes/reference/templates/notifications.md
+++ b/themes/reference/templates/notifications.md
@@ -99,7 +99,7 @@ In the "Classic" Theme, [notifications are implemented as a partial template fil
 
 ## Add your own message in your front controller
 
-Your front controller holds [the 4 following variables](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/controller/FrontController.php#L637-L640):
+Your front controller holds [the 4 following variables](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/controller/FrontController.php#L676-L680):
 
 * ``$this->errors``
 * ``$this->success``
@@ -108,7 +108,7 @@ Your front controller holds [the 4 following variables](https://github.com/Prest
 
 They are PHP arrays, and they hold messages as a string.
 
-Here is how you can [redirect the customer AND display a message after an action](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/controller/FrontController.php#L634-L653):
+Here is how you can [redirect the customer AND display a message after an action](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/controller/FrontController.php#L674-L693):
 
 ```php
 $this->success[] = $this->l('Information successfully updated.');

--- a/themes/reference/templates/templates-layouts.md
+++ b/themes/reference/templates/templates-layouts.md
@@ -73,7 +73,7 @@ When searching for a template, PrestaShop will check many location to determine
 which file should be used. It make it very easy to have different template for a
 given locale or a specific entity id.
 
-More details in [TemplateFinder.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/classes/Smarty/TemplateFinder.php#L71-L117).
+More details in [TemplateFinder.php](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/Smarty/TemplateFinder.php#L48-L94).
 
 #### Product page example
 

--- a/webservice/tutorials/creating-access.md
+++ b/webservice/tutorials/creating-access.md
@@ -69,7 +69,7 @@ $apiAccess->save();
 This first code allows you to pass the authentication layer. You also need access to the resources you expect to use.
 
 We need the Api account ID in order to grant it access, and an array having the resource name as key and the array of methods allowed as value.
-The available resources can be found in [`WebserviceRequest::getResources()` (link to definition)](https://github.com/PrestaShop/PrestaShop/blob/8.0.0/classes/webservice/WebserviceRequest.php#L282]).
+The available resources can be found in [`WebserviceRequest::getResources()` (link to definition)](https://github.com/PrestaShop/PrestaShop/blob/9.1.0/classes/webservice/WebserviceRequest.php#L254]).
 
 For instance is we want to give all permissions for customers and orders resources for the account we previously created:
 


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch?           | 9.x |
| Description?      | Pins GitHub links that use line anchors (#L...) to the 9.1.0 tag to avoid line drift and keep references stable over time. Includes related updates where examples must align with pinned references. |
| Fixed ticket?     | N/A |