### PR TITLE
Fix incorrect internal documentation links for the 9.1.x transition

### DIFF
--- a/basics/installation/advanced/nginx.md
+++ b/basics/installation/advanced/nginx.md
@@ -175,4 +175,4 @@ server {
 }
 ```
 
-[nginx-scale]: {{< ref "8/scale/webservers/nginx" >}}
+[nginx-scale]: {{< ref "/9/scale/webservers/nginx" >}}

--- a/basics/installation/environments/macos-specific.md
+++ b/basics/installation/environments/macos-specific.md
@@ -18,7 +18,7 @@ Several options are available, such as:
 
 ## Use Docker to run PrestaShop on MacOS
 
-Another good option when it comes to run PrestaShop on MacOS, is to use `Docker`: [More informations on this dedicated page]({{< relref "8/basics/installation/environments/docker">}}).
+Another good option when it comes to run PrestaShop on MacOS, is to use `Docker`: [More informations on this dedicated page]({{< relref "/9/basics/installation/environments/docker">}}).
 
 {{<cta relref="/9/basics/installation" type="primary">}}
   Back to installation guide

--- a/development/components/console/prestashop-linter-legacy-link.md
+++ b/development/components/console/prestashop-linter-legacy-link.md
@@ -13,4 +13,4 @@ weight: 20
 
 ## Description
 
-This command aims to check if [_legacy_link]({{< relref "/9/development/architecture/migration-guide/controller-routing#routing-in-prestashop" >}}) is configured in BackOffice routes.
+This command aims to check if [_legacy_link]({{< relref "/9/development/architecture/migration-guide/controller-routing.md" >}}) is configured in BackOffice routes.

--- a/development/components/export/csv-response.md
+++ b/development/components/export/csv-response.md
@@ -134,7 +134,7 @@ When looping over your `callback function`, the `CsvResponse` is retrieving `$li
 ```
 
 {{% notice note %}}
-A good example implementation of `CsvResponse::MODE_OFFSET` can be seen in [ProductCsvExporter.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Core/Product/ProductCsvExporter.php#L56-L97)
+A good example implementation of `CsvResponse::MODE_OFFSET` can be seen in [ProductCsvExporter.php](https://github.com/PrestaShop/PrestaShop/blob/8.0.0/src/Core/Product/ProductCsvExporter.php#L56-L97)
 {{% /notice %}}
 
 #### Manually setting $start parameter

--- a/development/components/hook/register-new-hook.md
+++ b/development/components/hook/register-new-hook.md
@@ -52,7 +52,7 @@ The previous step only adds the hook to _new_ shops. We also need to register th
 The last step is to insert the new hooks in the `ps_hooks` table using the upgrade system. Locate the X.Y.Z.sql file that refers to the PrestaShop version that will include your change: for instance, if the release expected to include this change is `1.7.5.0`, locate that file in the `upgrade/sql` folder from the [Update assistant](https://github.com/PrestaShop/autoupgrade) module.
 
 {{% notice tip %}}
-This process is explained here: [Structure and content upgrades]({{< ref "/9/development/database/structure.md#structure-and-content-upgrades" >}})
+This process is explained here: [Structure and content updates]({{< ref "/9/development/database/structure.md#structure-and-content-updates" >}})
 {{% /notice %}}
 
 Once you have located the file, add the corresponding SQL commands to add new hooks:

--- a/faq/assets-compilation-problems.md
+++ b/faq/assets-compilation-problems.md
@@ -9,4 +9,4 @@ If you encounter the error message `Template "@AdminNewTheme/public/preload.html
 
 To resolve this issue please make sure to compile the assets correctly, you can see the [assets compilation documentation][assets-compilation] for more information.
 
-[assets-compilation]: {{< relref "9/development/compile-assets" >}}
+[assets-compilation]: {{< relref "/9/development/compile-assets" >}}

--- a/modules/concepts/controllers/admin-controllers/override-decorate-controller.md
+++ b/modules/concepts/controllers/admin-controllers/override-decorate-controller.md
@@ -52,7 +52,7 @@ In the above example, the `path` has not been changed, but you can change it to 
 {{% /notice %}}
 
 {{% notice warning %}}
-Keep the item `_legacy_controller` if your controller relies on it to configure a [AdminSecurity annotation]({{< relref "8/development/architecture/migration-guide/controller-routing#access-rules-convention" >}}) such as `@AdminSecurity("is_granted('read', request.get('_legacy_controller'))")`
+Keep the item `_legacy_controller` if your controller relies on it to configure a [AdminSecurity annotation]({{< relref "/9/development/architecture/modern/controller-routing.md#access-rules-convention" >}}) such as `@AdminSecurity("is_granted('read', request.get('_legacy_controller'))")`
 
 Keep the items `_legacy_controller` and `_legacy_link` if you want to reroute internal links and legacy URLs like `index.php?controller=AdminOrders` as well.
 {{% /notice %}}
@@ -79,8 +79,8 @@ With the following configuration item, we can override this configuration to mak
 # modules/your-module/config/services.yml
   'PrestaShopBundle\Controller\Admin\Improve\Design\CmsPageController':
     class: MyModule\Controller\DemoController
-
 ```
+
 
 Thanks to this, whenever Symfony forwards a request to the Core controller `PrestaShopBundle\Controller\Admin\Improve\Design\CmsPageController` it will be forwarded to `DemoController` instead.
 
@@ -109,7 +109,7 @@ With the following configuration item, we can decorate it with a custom controll
   custom_controller:
     class: MyModule\Controller\DemoController
     decorates: PrestaShopBundle\Controller\Admin\Improve\Design\CmsPageController
-    arguments: ['@custom_controller.inner']
+    arguments: ["@custom_controller.inner"]
 ```
 
 or if you are using [autowiring](https://symfony.com/doc/4.4/service_container/autowiring.html):

--- a/modules/concepts/controllers/admin-controllers/tabs.md
+++ b/modules/concepts/controllers/admin-controllers/tabs.md
@@ -211,7 +211,7 @@ When you create a new `Tab` it automatically creates the appropriate roles in `T
 - `ROLE_MOD_TAB_ADMINLINKWIDGET_READ`
 - `ROLE_MOD_TAB_ADMINLINKWIDGET_UPDATE`
 
-These roles will allow you to manage detailed permission in your controllers, you can read this documentation if you need more details about [Controller Security]({{< ref "/9/development/architecture/migration-guide/controller-routing.md#security" >}}).
+These roles will allow you to manage detailed permission in your controllers, you can read this documentation if you need more details about [Controller Security]({{< ref "/9/development/architecture/modern/controller-routing.md#security" >}}).
 They are automatically added to the `SUPER_ADMIN` group, and the group of the Employee installing the module, but you can then edit privileges for other Employee groups.
 
 {{% notice note %}}

--- a/modules/concepts/doctrine/how-to-handle-multi-lang-doctrine-entity.md
+++ b/modules/concepts/doctrine/how-to-handle-multi-lang-doctrine-entity.md
@@ -25,7 +25,7 @@ There are several Doctrine plugins which allows to handle multi lang fields easi
 
 {{% notice note %}}
 **Namespace and autoload**
-The content of this documentation relies on **namespaces** which need to be defined in your module's autoload, we won't cover this part here if you need more information please read [how to setup composer in a module]({{< ref "8/modules/concepts/composer#setup-composer-in-a-module" >}})
+The content of this documentation relies on **namespaces** which need to be defined in your module's autoload, we won't cover this part here if you need more information please read [how to setup composer in a module]({{< ref "/9/modules/concepts/composer#setup-composer-in-a-module" >}})
 {{% /notice %}}
 
 {{% notice tip %}}

--- a/modules/concepts/forms/admin-forms.md
+++ b/modules/concepts/forms/admin-forms.md
@@ -10,7 +10,7 @@ One of the most common tasks for the PrestaShop developers is to alter the data 
 {{% notice info %}}
 **This system only works with pages from the "Configure" section of your back office.**
 
-If you want to customize an entity form, you're looking for [Grid]({{<relref "9/development/components/grid/" >}}) and [Identifiable Objects]({{<relref "/9/development/architecture/migration-guide/forms/crud-forms">}}).
+If you want to customize an entity form, you're looking for [Grid]({{<relref "/9/development/components/grid/" >}}) and [Identifiable Objects]({{<relref "/9/development/architecture/migration-guide/forms/crud-forms">}}).
 
 Learn how to achieve this with the [Grid and identifiable object form hooks usage example]({{<relref "/9/modules/sample-modules/grid-and-identifiable-object-form-hooks-usage">}}).
 {{% /notice %}}
@@ -66,7 +66,7 @@ Of course, you can override every template to improve again the rendering of the
             <div class="card-block">
                 <div class="card-text">
                     <div class="form-group">
-                        {{ ps.label_with_help(('Maximum size for attached files'|trans), ('Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).'|trans({'%size%': 'PS_ATTACHMENT_MAXIMUM_SIZE'|configuration}, 'Admin.Advparameters.Help'))) }}
+                        {{ ps.label_with_help(('Maximum size for attached files'|trans), ('Set the maximum size allowed for attachment files (in megabytes). This value has to be lower or equal to the maximum file upload allotted by your server (currently: %size% MB).'|trans({'%size%': 'PS_ATTACHMENT_MAXIMUM_SIZE'|configuration}, 'Admin.Advparameters.Help'))) }} 
                         {{ form_errors(uploadQuotaForm.max_size_attached_files) }}
                         {{ form_widget(uploadQuotaForm.max_size_attached_files) }}
                     </div>

--- a/modules/concepts/hooks/_index.md
+++ b/modules/concepts/hooks/_index.md
@@ -40,7 +40,7 @@ public function install()
 }
 ```
 
-If you do not know where you can register, [a list of available hooks]({{< ref "8/modules/concepts/hooks/list-of-hooks" >}}) is available.
+If you do not know where you can register, [a list of available hooks]({{< ref "/9/modules/concepts/hooks/list-of-hooks" >}}) is available.
 
 ### Execution
 

--- a/modules/concepts/mail-templates/_index.md
+++ b/modules/concepts/mail-templates/_index.md
@@ -5,7 +5,7 @@ title: Mail Templates
 # Mail Templates
 {{< minver v="1.7.6" title="true" >}}
 
-PrestaShop 1.7.6 introduced [Mail themes]({{< ref "1.7/development/components/mail-templates/" >}}). This new mail template management feature provides new and powerful ways for Modules to interact with mail templates.
+PrestaShop 1.7.6 introduced [Mail themes]({{< ref "/1.7/development/components/mail-templates/" >}}). This new mail template management feature provides new and powerful ways for Modules to interact with mail templates.
  
 ## Tutorials
 

--- a/modules/concepts/overrides.md
+++ b/modules/concepts/overrides.md
@@ -28,7 +28,7 @@ Before creating an override, check the existing features can help you:
 There are many events triggered on each controller of PrestaShop. They can be used
 for displaying additional content or executing module actions.
 
-See [the hooks chapter]({{< ref "8/modules/concepts/hooks/" >}}) for more details.
+See [the hooks chapter]({{< ref "/9/modules/concepts/hooks/" >}}) for more details.
 
 ### Classes
 
@@ -65,13 +65,13 @@ Core controllers can be reused in a module as well, without being erased, thanks
 
 This allows a controller to be maintained easily, with its own identity but with the parent features.
 
-See [the controllers chapter]({{< ref "8/modules/concepts/controllers/" >}}) for more details.
+See [the controllers chapter]({{< ref "/9/modules/concepts/controllers/" >}}) for more details.
 
 ### Service overrides
 
 PrestaShop is migrating to Symfony, and the parts migrated rely on Symfony container which enables service overrides and decorations. This is similar to overrides but avoids class erasing.
 
-See [the Symfony services chapter]({{< ref "8/modules/concepts/services/" >}}) for more details.
+See [the Symfony services chapter]({{< ref "/9/modules/concepts/services/" >}}) for more details.
 
 ### Contributing
 

--- a/modules/concepts/services/_index.md
+++ b/modules/concepts/services/_index.md
@@ -17,7 +17,7 @@ You have the ability to modify the Symfony container configuration from a module
 
 First we strongly advise you to use
 [**namespaces**](https://www.php.net/manual/en/language.namespaces.php) & autoloading in your module, which can be done thanks to composer.
-[A dedicated chapter]({{< ref "8/modules/concepts/composer" >}}) is available to learn more about Composer and to set it up.
+[A dedicated chapter]({{< ref "/9/modules/concepts/composer.md" >}}) is available to learn more about Composer and to set it up.
 
 #### Define your service
 
@@ -126,7 +126,7 @@ When adding resources with a wildcard to your module namespace, make sure to exc
     resource: '../src/*'
     exclude:
       - '../src/index.php'
-      - '../src/*/index.php' 
+      - '../src/*/index.php'
 ```
 
 ### Override an existing Symfony service
@@ -372,7 +372,7 @@ services:
     public: true
     bind:
       $elements: !tagged test_module.instance_of.manually_tagged
-  
+
   TestModule\InstanceofConditionals\Collection\Element:
     class: TestModule\InstanceofConditionals\Collection\Element
     tags: [ test_module.instance_of.manually_tagged ]
@@ -399,7 +399,7 @@ files in sub folders:
 {{% notice warning %}}
 **Do not use named arguments for front services definition**
 
-For more information read the dedicated section in [Naming Conventions]({{< ref "8/development/naming-conventions/#named-arguments" >}}).
+For more information read the dedicated section in [Naming Conventions]({{< ref "/9/development/naming-conventions/_index.md#named-arguments" >}}).
 {{% /notice %}}
 
 ### Accessing your services

--- a/modules/core-updates/8.1.md
+++ b/modules/core-updates/8.1.md
@@ -48,7 +48,7 @@ The new Product page in Back Office has been introduced. [Discover how to extend
 * Added a new Smarty variable `theme_dir` in front controllers [PR#30383](https://github.com/PrestaShop/PrestaShop/pull/30383)
 * Added a feature to disable `core.js` loading on custom themes [PR#29995](https://github.com/PrestaShop/PrestaShop/pull/29995). [More informations][corejs-informations]
 * Added supplier url and manufacturer url to Smarty `{url}` helper [PR#30242](https://github.com/PrestaShop/PrestaShop/pull/30342) and [PR#30314](https://github.com/PrestaShop/PrestaShop/pull/30314)
-* Fixed modules autoloaders and service configurations registrations priority [PR#30588](https://github.com/PrestaShop/PrestaShop/pull/30588). [More informations]({{< relref "/9/modules/concepts/services/#advanced-services-parameters-_instanceof-or-interface-binding-manual-tags" >}})
+* Fixed modules autoloaders and service configurations registrations priority [PR#30588](https://github.com/PrestaShop/PrestaShop/pull/30588). [More informations]({{< relref "/9/modules/concepts/services/_index.md#advanced-services-parameters-_instanceof-or-interface-binding-manual-tags" >}})
 * Introduced `actionLoggerLogMessage` hook [PR#28999](https://github.com/PrestaShop/PrestaShop/pull/28999). [Hook details page]({{< relref "/9/modules/concepts/hooks/list-of-hooks/actionLoggerLogMessage">}})
 * Unregistered hooks are now collected in debug toolbar [PR#29314](https://github.com/PrestaShop/PrestaShop/pull/29314)
 * Added `Sortable` Javascript library to the core [PR#30225](https://github.com/PrestaShop/PrestaShop/pull/30225)
@@ -103,6 +103,6 @@ Every linked dependencies were also bumped to higher version to keep 3.2 compati
 Please refer to: [PR#28463](https://github.com/PrestaShop/PrestaShop/pull/28463) for an exhaustive list.
 {{% /notice %}}
 
-[80-changes]: {{< relref "8/modules/core-updates/8.0.md" >}}
-[corejs-informations]: {{< relref "8/themes/getting-started/theme-yml" >}}
-[new-product-page]: {{< relref "8/modules/sample-modules/extend-product-page" >}}
+[80-changes]: {{< relref "/8/modules/core-updates/8.0.md" >}}
+[corejs-informations]: {{< relref "/8/themes/getting-started/theme-yml" >}}
+[new-product-page]: {{< relref "/8/modules/sample-modules/extend-product-page" >}}

--- a/modules/core-updates/9.0.md
+++ b/modules/core-updates/9.0.md
@@ -290,7 +290,7 @@ We still had to change the controller workflow. Many of the functions in `AdminC
 
 **Legacy workflow:**
 
-Here you'll find the [execution workflow of legacy controllers]({{< relref "9/development/architecture/legacy/legacy-controllers.md" >}})
+Here you'll find the [execution workflow of legacy controllers]({{< relref "/9/development/architecture/legacy/legacy-controllers.md" >}})
 
 **Symfony workflow:**
 
@@ -347,7 +347,7 @@ For more details about the changes, you can check the content of the <a href="ht
 The back office login page has been migrated to Symfony. Along with this change, the authorization system in the back office is now also based on Symfony, which implies several things:
 - we no longer depend on the legacy `Context::$cookie`, the session is kept on the server side, and very few data are kept on the browser side. For retro-compatibility, we still populate the legacy cookie so that you can **read** it. While you can use `Context::$cookie` for your custom data, making changes to the data previously used for PrestaShop authorization will no longer have the desired effect and may even result in instability, so it's not recommended
 - the `PrestaShopBundle\Security\Admin\EmployeeProvider` and `PrestaShopBundle\Service\DataProvider\UserProvider` now return a `PrestaShopBundle\Entity\Employee` instance, their responsibility is to return a `Symfony\Component\Security\Core\User\UserInterface` anyway (and they still do) but in case you depended on the child class know that `PrestaShopBundle\Security\Admin\Employee` no longer exist
-- if you need to get the logged-in user, you can use the Symfony `Symfony\Bundle\SecurityBundle\Security` service, but we recommend you use the `EmployeeContext` internal PrestaShop service (see explanation about [new Contexts]({{< relref "9/modules/core-updates/9.0.md#symfony-context-refacto" >}}))
+- if you need to get the logged-in user, you can use the Symfony `Symfony\Bundle\SecurityBundle\Security` service, but we recommend you use the `EmployeeContext` internal PrestaShop service (see explanation about [new Contexts]({{< relref "/9/modules/core-updates/9.0.md#symfony-context-refactorization" >}}))
 
 **Storing custom data in a Session**
 
@@ -794,7 +794,7 @@ The PrestaShop back office consists of [two themes][bo-themes]. Both themes have
 - Utilizes the **PrestaShop UI Kit**
 
 [bo-themes]: {{< ref "/9/development/architecture/introduction.md#bo-themes" >}}
-[new-product-page]: {{< relref "9/modules/sample-modules/extend-product-page" >}}
+[new-product-page]: {{< relref "/9/modules/sample-modules/extend-product-page" >}}
 
 ## Miscellaneous changes
 

--- a/modules/creation/_index.md
+++ b/modules/creation/_index.md
@@ -11,7 +11,7 @@ If you want to get started quickly with a ready-to-use module template, you can 
 Other skeletons have been created to help you create specific modules:
 
 * [Skeleton of a Payment module for PrestaShop 1.7](https://github.com/PrestaShop/paymentexample)
-* [Skeleton of a module using CQRS feature](https://github.com/friends-of-presta/demo-cqrs-hooks-usage-module) ([More details about CQRS]({{< ref "8/development/architecture/domain/_index.md" >}}))
+* [Skeleton of a module using CQRS feature](https://github.com/friends-of-presta/demo-cqrs-hooks-usage-module) ([More details about CQRS]({{< ref "/9/development/architecture/domain/_index.md" >}}))
 
 ## In this section 
 

--- a/modules/creation/adding-configuration-page-modern.md
+++ b/modules/creation/adding-configuration-page-modern.md
@@ -44,7 +44,7 @@ class DemoSymfonyFormSimple extends Module
             'Modules.Demosymfonyformsimple.Admin'
         );
 
-        $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => '8.99.99'];
+        $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => '9.99.99'];
     }
 }
 ```

--- a/modules/creation/external-services.md
+++ b/modules/creation/external-services.md
@@ -22,8 +22,8 @@ It uses Basic access authentication to allow requests.
 
 **Resources:**
 
-* [About the webservice]({{< ref "8/webservice" >}})
-* [Enable & add users to the webservice]({{< ref "8/webservice/tutorials/creating-access" >}})
+* [About the webservice]({{< ref "/9/webservice" >}})
+* [Enable & add users to the webservice]({{< ref "/9/webservice/tutorials/creating-access" >}})
 
 **Adding a module ObjectModel to the list of resources available**
 
@@ -63,7 +63,7 @@ This can be done by generating your own token and checking it everytime the cont
 
 **Resources:**
 
-* [About the controllers]({{< ref "8/modules/concepts/controllers/front-controllers" >}})
+* [About the controllers]({{< ref "/9/modules/concepts/controllers/front-controllers.md" >}})
 * [Example with Faceted Search module (Outside a controller)](https://github.com/PrestaShop/ps_facetedsearch/blob/6f7b97e77b0fca30c0acf74316996cfc82a263a9/ps_facetedsearch-clear-cache.php#L6-L8)
 
 

--- a/modules/creation/module-translation/new-system.md
+++ b/modules/creation/module-translation/new-system.md
@@ -367,4 +367,4 @@ If you choose to export wordings from the database, you can easily extract your 
 
 [contextualization]: {{< ref "new-system.md#contextualization" >}}
 [native-module-conventions]: {{< ref "/9/development/internationalization/translation/translation-domains.md#modules" >}}
-[core-translation-domains]: {{< ref "/9/development/internationalization/translation/translation-domains.md#understanding-the-domains-structure" >}}
+[core-translation-domains]: {{< ref "/9/development/internationalization/translation/translation-domains.md#understanding-the-structure-of-domains" >}}

--- a/modules/testing/advanced-checks.md
+++ b/modules/testing/advanced-checks.md
@@ -141,7 +141,7 @@ composer require --dev phpunit/phpunit
 While newer versions of PHPUnit exist, the version chosen in your project must match the PHP compatibility range of the project, otherwise composer will refuse to install it. The version provided in the example above is the last one compatible with PHP 5.6.
 
 Creating your unit tests can be done the same way as the core, so more details can be found in 
-the chapter [Testing of the core]({{< ref "1.7/testing/how-to-create-your-own-unit-tests" >}}).
+the chapter [Testing of the core]({{< ref "/9/testing/how-to-create-your-own-unit-tests/" >}}).
 
 Supposing it was installed via Composer, the command to run it is:
 

--- a/modules/testing/advanced-checks.md
+++ b/modules/testing/advanced-checks.md
@@ -141,7 +141,7 @@ composer require --dev phpunit/phpunit
 While newer versions of PHPUnit exist, the version chosen in your project must match the PHP compatibility range of the project, otherwise composer will refuse to install it. The version provided in the example above is the last one compatible with PHP 5.6.
 
 Creating your unit tests can be done the same way as the core, so more details can be found in 
-the chapter [Testing of the core]({{< ref "/9/testing/how-to-create-your-own-unit-tests/" >}}).
+the chapter [Testing of the core]({{< ref "9/testing/unit-tests/how-to-create-your-own-unit-tests" >}}).
 
 Supposing it was installed via Composer, the command to run it is:
 

--- a/modules/testing/basic-checks.md
+++ b/modules/testing/basic-checks.md
@@ -48,7 +48,7 @@ If some errors are reported by this tool, this gives you the opportunity :
 
 ## Coding standards
 
-Modules follows the same rules as the core. The [coding standards chapter]({{< ref "8/development/coding-standards" >}}) of this project provides more details about it.
+Modules follows the same rules as the core. The [coding standards chapter]({{< ref "/9/development/coding-standards" >}}) of this project provides more details about it.
 
 Following the same rules as the core requires the configuration file to be available in your project. These rules are distributed and maintained on a repository 
 `prestashop/php-dev-tools` available on [Packagist](https://packagist.org/packages/prestashop/php-dev-tools) which can be required via composer.


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch?           | 9.x |
| Description?      | Fixes incorrect internal documentation links introduced during transition from legacy references to PrestaShop 9.1.x paths. |
| Fixed ticket?     | N/A |