### PR TITLE
Fix method signature for fetchGitHubInformation

### DIFF
--- a/modules/creation/external-services.md
+++ b/modules/creation/external-services.md
@@ -86,7 +86,7 @@ class SymfonyDocs
     ) {
     }
 
-    public function fetchGitHubInformation(): array
+    public function fetchGitHubInformation()
     {
         $response = $this->client->request(
             'GET',


### PR DESCRIPTION
the return type of $response->getContent() is not an array

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.x


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
