### PR TITLE
Add '--skip-overrides' option to module command

### DIFF
--- a/development/components/console/prestashop-module.md
+++ b/development/components/console/prestashop-module.md
@@ -14,6 +14,8 @@ weight: 10
   * `action`: Action to execute, must be one of: install, uninstall, enable, disable, reset, upgrade, configure, delete
   * `module name`: Module on which the action will be executed
   * `file path`: YML file path for configuration __(optional, only used with configure action)__
+* Options:
+  * `--skip-overrides`: prevent the module's override files from being copied to (or removed from) the /override/ directory (since 9.1.1). 
 
 ## Description
 


### PR DESCRIPTION
Added options for skipping module overrides in command.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | Add '--skip-overrides' option to module command
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/40612
| Sponsor company   | Creabilis.com

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
