### PR TITLE
Clarify MaterialChoiceTableType multiple selection

### DIFF
--- a/development/components/form/types-reference/material-choice-table.md
+++ b/development/components/form/types-reference/material-choice-table.md
@@ -4,15 +4,15 @@ title: MaterialChoiceTableType
 
 # MaterialChoiceTableType
 
-MaterialChoiceTableType renders checkbox choices using table layout. It requires Javascript component to work as expected.
+MaterialChoiceTableType renders multiple checkbox choices using a table layout. It requires Javascript component to work as expected.
 
 ## Type options
 
 | Option   | Type | Default value | Description                                            |
 |:---------|:-----|:--------------|:-------------------------------------------------------|
 | expanded | bool | true          | Whether the table should be expanded by default or not |
-| multiple | bool | true          | Whether to enable multiple checkboxes selection or not  |
-| display_total_items | bool | true | Whether to display the total number of items or not |
+| multiple | bool | true          | Multiple selection is always enabled and cannot be disabled  |
+| display_total_items | bool | false | Whether to display the total number of items or not |
 
 ## Required Javascript components
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop-project.org/9/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | This PR updates the `MaterialChoiceTableType` documentation to clarify that this form type only supports multiple selection.<br/><br/>The `multiple` option is inherited from Symfony's `ChoiceType`, but it cannot be disabled because `MaterialChoiceTableType` is designed to render multiple checkboxes and provide a “Select all” feature.<br/><br/>Related core PR: PrestaShop/PrestaShop#42140
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39273
| Sponsor company   | Codencode snc

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
