### PR TITLE
Document actionNotFound hook

### DIFF
--- a/modules/concepts/hooks/list-of-hooks/actionNotFound.md
+++ b/modules/concepts/hooks/list-of-hooks/actionNotFound.md
@@ -1,0 +1,33 @@
+---
+Title: actionNotFound
+hidden: true
+hookTitle: 'Action when a page is not found'
+files:
+    -
+        url: 'https://github.com/PrestaShop/PrestaShop/blob/9.2.x/controllers/front/PageNotFoundController.php'
+        file: controllers/front/PageNotFoundController.php
+    -
+        url: 'https://github.com/PrestaShop/PrestaShop/blob/9.2.x/controllers/front/ProductController.php'
+        file: controllers/front/ProductController.php
+    -
+        url: 'https://github.com/PrestaShop/PrestaShop/blob/9.2.x/controllers/front/listing/CategoryController.php'
+        file: controllers/front/listing/CategoryController.php
+locations:
+    - 'front office'
+type: action
+hookAliases: 
+array_return: false
+check_exceptions: false
+chain: false
+origin: core
+description: 'Allows modules to react when a page is not found - log it, redirect or perform other actions.'
+
+---
+
+{{% hookDescriptor %}}
+
+## Call of the Hook in the origin file
+
+```php
+Hook::exec('actionNotFound');
+```


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | Adds the missing documentation page for the `actionNotFound` hook. The hook was introduced by PrestaShop/PrestaShop@4ee3078 and **first shipped in 9.1.5**; it is also present in 9.2.x. It went undocumented for a scheduling reason: that commit landed on 2026-07-09 at 14:35, a few hours after #2158 regenerated the hook documentation at 11:43 the same day — so the generator run never saw it. Running `php bin/console prestashop:update:hooks-documentation` against current `9.x` produces exactly this one new file and modifies nothing else. Two manual notes: the `files:` list was completed by hand, because the generator only records a single origin file while `actionNotFound` is dispatched from three front controllers (`PageNotFoundController`, `ProductController`, `listing/CategoryController`); and the URLs point at `9.2.x` rather than `9.1.x` because the `9.1.x` branch has since been deleted upstream, which would make those links dead.
| Fixed ticket?     | —
| Sponsor company   | PrestaShop