### PR TITLE
Say which container $this->get() resolves against in the front office

### DIFF
--- a/modules/concepts/services/_index.md
+++ b/modules/concepts/services/_index.md
@@ -8,6 +8,20 @@ weight: 8
 
 ## Symfony Services
 
+{{% notice warning %}}
+**`$this->get()` resolves against the container of the context you are in, which is not always the full Symfony container.**
+
+In the back office, and in pages already migrated to Symfony, you get the full container: `router`, `translator`
+and anything you declared in `config/services.yml` are available. A front office page still runs a legacy
+controller, and there `$this->get()` resolves against the light front container instead. It holds Doctrine and
+the services declared in `<PS_ROOT_DIR>/config/services/front/`, and nothing else: asking it for `router` or
+`translator` raises a `ServiceNotFoundException`, `$this->getTwig()` returns `null`, and
+`SymfonyContainer::getInstance()` is `null` there too.
+
+A service you want to call from a front office hook has to be declared in your module's `config/front/` folder.
+See [Services in Legacy environment](#services-in-legacy-environment) below.
+{{% /notice %}}
+
 You have the ability to modify the Symfony container configuration from a module. This means that
 
 - You have the possibility to define your own Symfony services from your modules.


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.x
| Description?      | The `Symfony Services` section of `modules/concepts/services` describes `config/services.yml` and `$this->get()` with no indication that both only apply to the back office and to pages already migrated to Symfony. The front office caveat exists but sits under `Services in Legacy environment`, several screens further down, which is where a reader lands only after the call has already thrown. Adds a warning notice at the top of the section naming what resolves where, and linking to the existing section.
| Fixed ticket?     | Related to PrestaShop/PrestaShop#29013
| Sponsor company   |

### Why here

#29013 is a module author following the top of this page and getting
`You have requested a non-existent service "twig"` from a front office hook. Twenty-one comments and three
community members later, the answer was the paragraph further down the same page. The page is not wrong;
the scoping is stated too late to help.

### The facts the notice states, measured on 9.2

A probe module hooked on `displayFooterProduct`, hit through a real front office product page:

```
$this->get('router')                    ServiceNotFoundException: non-existent service "router"
$this->get('twig')                      NULL           (9.0+ routes it to getTwig())
$this->get('translator')                ServiceNotFoundException
$this->get('prestashop.adapter.legacy.context')   PrestaShop\PrestaShop\Adapter\LegacyContext
$this->getTwig()                        NULL
SymfonyContainer::getInstance()         NULL
container class                         FrontContainer, 109 services
```

The 109 are Doctrine plus `prestashop.adapter.*` / `prestashop.core.*` entries; the only translation-ish
one is `prestashop.translation.translator_language_loader`. No count is quoted in the notice, since it
would go stale.
